### PR TITLE
Added KSP Stock Tags to Parts, fixed some Typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ GameData/B9_Aerospace/Parts/Aero_Wing_Procedural/wing_edge_layered.dds
 GameData/B9_Aerospace/Parts/Aero_Wing_Procedural/wing_surface_layered.dds
 GameData/KineTechAnimation/Plugins/PluginData/KineTechAnimation/Settings.KineTechAnimation
 PluginData
+*.bak

--- a/GameData/B9_Aerospace/Parts/Adapter_C125/Adapter_C125.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_C125/Adapter_C125.cfg
@@ -42,4 +42,5 @@ PART
     maxTemp = 2000 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1
+    tags = adapter affix body connect extend frame mount shuttle separat stru support wobble
 }

--- a/GameData/B9_Aerospace/Parts/Adapter_M1/Adapter_SM1.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_M1/Adapter_SM1.cfg
@@ -50,18 +50,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 60.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Adapter_M1/Adapter_SM1.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_M1/Adapter_SM1.cfg
@@ -42,6 +42,7 @@ PART
     maxTemp = 2100 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size0, size1
+    tags = adapter affix build connect extend mount pair stack
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Adapter_M2/Adapter_SM2.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_M2/Adapter_SM2.cfg
@@ -50,18 +50,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 90.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Adapter_M2/Adapter_SM2.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_M2/Adapter_SM2.cfg
@@ -42,6 +42,7 @@ PART
     maxTemp = 2200 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1, size2
+    tags = adapter affix build connect extend mount pair stack
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Adapter_M3/LM3.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_M3/LM3.cfg
@@ -53,18 +53,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 182.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Adapter_M3/LM3.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_M3/LM3.cfg
@@ -45,6 +45,7 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size2, size3
+    tags = adapter affix build connect extend mount pair stack
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Adapter_M3/SM3.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_M3/SM3.cfg
@@ -53,18 +53,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 90.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Adapter_M3/SM3.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_M3/SM3.cfg
@@ -45,6 +45,7 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size2, size3
+    tags = adapter affix build connect extend mount pair stack
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Adapter_Y1/Adapter_Y1.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_Y1/Adapter_Y1.cfg
@@ -46,24 +46,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 36.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
-	
+
 		SUBTYPE
 		{
 			name = Battery

--- a/GameData/B9_Aerospace/Parts/Adapter_Y1/Adapter_Y1.cfg
+++ b/GameData/B9_Aerospace/Parts/Adapter_Y1/Adapter_Y1.cfg
@@ -38,6 +38,7 @@ PART
     crashTolerance = 12
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size3
+    tags = )cap adapter affix build connect extend frame join mount separat split stack structur
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_Airbrake_Surface/airbrake.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Airbrake_Surface/airbrake.cfg
@@ -37,6 +37,7 @@ PART
     breakingTorque = 50
     maxTemp = 2000 // = 3000
 	bulkheadProfiles = srf
+    tags = advanced aero aircraft command control fly maneuver manoeuvre plane rotate
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_Airbrake_Surface/airbrake_large.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Airbrake_Surface/airbrake_large.cfg
@@ -37,6 +37,7 @@ PART
     breakingTorque = 200
     maxTemp = 2000 // = 3000
 	bulkheadProfiles = srf
+    tags = advanced aero aircraft command control fly maneuver manoeuvre plane rotate
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Adapter_Front/Aero_HL_Adapter_Front.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Adapter_Front/Aero_HL_Adapter_Front.cfg
@@ -42,7 +42,7 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size3
-    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold liquid payload propellant structur tank
+    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold liquid mono monopropellant payload propellant structur tank
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Adapter_Front/Aero_HL_Adapter_Front.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Adapter_Front/Aero_HL_Adapter_Front.cfg
@@ -42,6 +42,7 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size3
+    tags = adapter aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Adapter_Front/Aero_HL_Adapter_Front.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Adapter_Front/Aero_HL_Adapter_Front.cfg
@@ -42,7 +42,7 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size3
-    tags = adapter aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
+    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold liquid payload propellant structur tank
 
 	MODULE
 	{
@@ -50,24 +50,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 4180.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal-SAS.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal-SAS.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 135360
     breakingTorque = 135360
 	bulkheadProfiles = size3
+    tags = advanced command control fly react rotate sas torque translate
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 203040
     breakingTorque = 203040
 	bulkheadProfiles = size3, srf
+    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal.cfg
@@ -46,7 +46,7 @@ PART
     breakingForce = 203040
     breakingTorque = 203040
 	bulkheadProfiles = size3, srf
-    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
+    tags = aircraft airlin airliner connect contain fuel fueltank freight hold liquid mono monopropellant payload propellant structur tank tube
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal.cfg
@@ -54,14 +54,14 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 900.0
-	
+
 		SUBTYPE
 		{
 			name = HL_Structural
 			title = HL (Structural)
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LF
@@ -69,7 +69,7 @@ PART
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LFO
@@ -77,7 +77,7 @@ PART
 			tankType = LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_RCS
@@ -85,7 +85,7 @@ PART
 			tankType = MonoPropellant
 			transform = RCS
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_Structural_1
@@ -94,7 +94,7 @@ PART
 			addedCost = 45.0
 			transform = STR_R1
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_Structural_2
@@ -103,7 +103,7 @@ PART
 			addedCost = 45.0
 			transform = STR_R2
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LF
@@ -114,7 +114,7 @@ PART
 			tankType = LiquidFuel
 			transform = LF_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LFO
@@ -125,7 +125,7 @@ PART
 			tankType = LFO
 			transform = LFO_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_RCS
@@ -136,7 +136,7 @@ PART
 			tankType = MonoPropellant
 			transform = RCS_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_Round_Adapter_Structural

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/1m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/1m-Universal.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 67680
     breakingTorque = 67680
 	bulkheadProfiles = size3
+    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/1m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/1m-Universal.cfg
@@ -54,14 +54,14 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 1780.0
-	
+
 		SUBTYPE
 		{
 			name = HL_Structural
 			title = HL (Structural)
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LF
@@ -69,7 +69,7 @@ PART
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LFO
@@ -77,7 +77,7 @@ PART
 			tankType = LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_RCS
@@ -85,7 +85,7 @@ PART
 			tankType = MonoPropellant
 			transform = RCS
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_Structural
@@ -94,7 +94,7 @@ PART
 			addedCost = 85.0
 			transform = STR_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LF
@@ -105,7 +105,7 @@ PART
 			tankType = LiquidFuel
 			transform = LF_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LFO
@@ -116,7 +116,7 @@ PART
 			tankType = LFO
 			transform = LFO_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_RCS

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/1m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/1m-Universal.cfg
@@ -46,7 +46,7 @@ PART
     breakingForce = 67680
     breakingTorque = 67680
 	bulkheadProfiles = size3
-    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
+    tags = aircraft airlin airliner connect contain fuel fueltank freight hold liquid mono monopropellant payload propellant structur tank tube
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Adapter-Side.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Adapter-Side.cfg
@@ -49,7 +49,7 @@ PART
     breakingForce = 12690
     breakingTorque = 12690
 	bulkheadProfiles = size3, srf
-    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold liquid payload structur tail tank tube
+    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold liquid mono monopropellant payload propellant structur tail tank tube
 
     MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Adapter-Side.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Adapter-Side.cfg
@@ -49,31 +49,32 @@ PART
     breakingForce = 12690
     breakingTorque = 12690
 	bulkheadProfiles = size3, srf
+    tags = adapter aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
 
-	MODULE
+    MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 4740.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Adapter-Side.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Adapter-Side.cfg
@@ -49,7 +49,7 @@ PART
     breakingForce = 12690
     breakingTorque = 12690
 	bulkheadProfiles = size3, srf
-    tags = adapter aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
+    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold liquid payload structur tail tank tube
 
     MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal-Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal-Adapter.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 5730
     breakingTorque = 5730
 	bulkheadProfiles = size3
-    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
+    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold liquid mono monopropellant payload propellant structur tank
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal-Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal-Adapter.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 5730
     breakingTorque = 5730
 	bulkheadProfiles = size3
+	tags = adapter aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
 
 	MODULE
 	{
@@ -52,14 +53,14 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 2580.0
-	
+
 		SUBTYPE
 		{
 			name = HL_Structural
 			title = HL (Structural)
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LF
@@ -67,7 +68,7 @@ PART
 			tankType = LiquidFuel
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LFO
@@ -75,7 +76,7 @@ PART
 			tankType = LFO
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_RCS
@@ -83,7 +84,7 @@ PART
 			tankType = MonoPropellant
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_Structural
@@ -92,7 +93,7 @@ PART
 			addedCost = 70.0
 			transform = STR_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LF
@@ -103,7 +104,7 @@ PART
 			tankType = LiquidFuel
 			transform = STR_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LFO
@@ -114,7 +115,7 @@ PART
 			tankType = LFO
 			transform = STR_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_RCS

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal-Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal-Adapter.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 5730
     breakingTorque = 5730
 	bulkheadProfiles = size3
-	tags = adapter aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
+    tags = ?lf ?lfo adapter aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 12690
     breakingTorque = 12690
 	bulkheadProfiles = size3, srf
-    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
+    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold liquid mono monopropellant payload propellant structur tank
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 12690
     breakingTorque = 12690
 	bulkheadProfiles = size3, srf
-    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
+    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal.cfg
@@ -30,7 +30,6 @@ PART
     title = HL 2m Universal Body
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -46,6 +45,7 @@ PART
     breakingForce = 12690
     breakingTorque = 12690
 	bulkheadProfiles = size3, srf
+    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
 
 	MODULE
 	{
@@ -53,14 +53,14 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 3580.0
-	
+
 		SUBTYPE
 		{
 			name = HL_Structural
 			title = HL (Structural)
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LF
@@ -68,7 +68,7 @@ PART
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LFO
@@ -76,7 +76,7 @@ PART
 			tankType = LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_RCS
@@ -84,7 +84,7 @@ PART
 			tankType = MonoPropellant
 			transform = RCS
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_Structural
@@ -93,7 +93,7 @@ PART
 			addedCost = 180.0
 			transform = STR_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LF
@@ -102,7 +102,7 @@ PART
 			tankType = LiquidFuel
 			transform = LF_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LFO
@@ -111,7 +111,7 @@ PART
 			tankType = LFO
 			transform = LFO_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_RCS

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/6m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/6m-Universal.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 1410
     breakingTorque = 1410
 	bulkheadProfiles = size3, srf
-    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
+    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/6m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/6m-Universal.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 1410
     breakingTorque = 1410
 	bulkheadProfiles = size3, srf
-    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank
+    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold liquid mono monopropellant payload propellant structur tank
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/6m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/6m-Universal.cfg
@@ -30,7 +30,6 @@ PART
     title = HL 6m Universal Body
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -46,6 +45,7 @@ PART
     breakingForce = 1410
     breakingTorque = 1410
 	bulkheadProfiles = size3, srf
+    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tank tube
 
 	MODULE
 	{
@@ -53,14 +53,14 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 10720.0
-	
+
 		SUBTYPE
 		{
 			name = HL_Structural
 			title = HL (Structural)
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LF
@@ -68,7 +68,7 @@ PART
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = HL_LFO
@@ -76,7 +76,7 @@ PART
 			tankType = LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_Structural
@@ -85,7 +85,7 @@ PART
 			addedCost = 530.0
 			transform = STR_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LF
@@ -96,7 +96,7 @@ PART
 			tankType = LiquidFuel
 			transform = LF_R
 		}
-	
+
 		SUBTYPE
 		{
 			name = Round_LFO

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail-Cargo.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail-Cargo.cfg
@@ -28,7 +28,6 @@ PART
     title = HL Cargo Fuselage Universal Tail Section
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes. This tail section comes in wide and narrow variety, consider using a narrow one for sleeker look if you don't need wide rovers to fit inside.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,1,1,0
 
@@ -44,6 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3
+    tags = aircraft airlin airliner contain equipment freight payload rovers tail transport
 
 	// Stock drag cube implementation might be ok here
 	

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail-Cargo.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail-Cargo.cfg
@@ -46,7 +46,7 @@ PART
     tags = aircraft airlin airliner contain equipment freight payload rovers tail transport
 
 	// Stock drag cube implementation might be ok here
-	
+
 //	EFFECTS
 //    {
 //        doorMotor
@@ -84,13 +84,13 @@ PART
 		moduleID = meshSwitch
 		switcherDescription = Subtype
 		affectDragCubes = false
-	
+
 		SUBTYPE
 		{
 			name = Narrow
 			transform = Tail_Narrow
 		}
-	
+
 		SUBTYPE
 		{
 			name = Wide
@@ -104,7 +104,7 @@ PART
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 5
-		
+
 		nodeOuterForeID = top
 	}
 }

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail-Cargo.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail-Cargo.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3
-    tags = ?lf ?lfo aircraft airlin airliner contain equipment freight fuel fueltank liquid mono monopropellant payload propellant rovers tail transport
+    tags = (stor aircraft airlin airliner cargo contain equipment freight payload rovers tail transport
 
 	// Stock drag cube implementation might be ok here
 

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail-Cargo.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail-Cargo.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3
-    tags = aircraft airlin airliner contain equipment freight payload rovers tail transport
+    tags = ?lf ?lfo aircraft airlin airliner contain equipment freight fuel fueltank liquid mono monopropellant payload propellant rovers tail transport
 
 	// Stock drag cube implementation might be ok here
 

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail.cfg
@@ -44,7 +44,7 @@ PART
     breakingForce = 2762
     breakingTorque = 2762
 	bulkheadProfiles = size3, srf
-    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tail tank tube
+    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold liquid payload structur tail tank tube
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail.cfg
@@ -29,7 +29,6 @@ PART
     title = HL 8m Universal Tail
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -45,6 +44,7 @@ PART
     breakingForce = 2762
     breakingTorque = 2762
 	bulkheadProfiles = size3, srf
+    tags = aircraft airlin airliner connect contain fuel fueltank freight hold payload structur tail tank tube
 
 	MODULE
 	{
@@ -52,14 +52,14 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 7120.0
-	
+
 		SUBTYPE
 		{
 			name = Raised_Structural
 			title = Raised (Structural)
 			transform = Tail_Raised
 		}
-	
+
 		SUBTYPE
 		{
 			name = Raised_LF
@@ -67,7 +67,7 @@ PART
 			tankType = LiquidFuel
 			transform = Tail_Raised
 		}
-	
+
 		SUBTYPE
 		{
 			name = Raised_LFO
@@ -75,14 +75,14 @@ PART
 			tankType = LFO
 			transform = Tail_Raised
 		}
-	
+
 		SUBTYPE
 		{
 			name = Lowered_Structural
 			title = Lowered (Structural)
 			transform = Tail_Lowered
 		}
-	
+
 		SUBTYPE
 		{
 			name = Lowered_LF
@@ -90,7 +90,7 @@ PART
 			tankType = LiquidFuel
 			transform = Tail_Lowered
 		}
-	
+
 		SUBTYPE
 		{
 			name = Lowered_LFO
@@ -98,14 +98,14 @@ PART
 			tankType = LFO
 			transform = Tail_Lowered
 		}
-	
+
 		SUBTYPE
 		{
 			name = Straight_A_Structural
 			title = Straight A (Structural)
 			transform = Tail_Straight_A
 		}
-	
+
 		SUBTYPE
 		{
 			name = Straight_A_LF
@@ -113,7 +113,7 @@ PART
 			tankType = LiquidFuel
 			transform = Tail_Straight_A
 		}
-	
+
 		SUBTYPE
 		{
 			name = Straight_A_LFO
@@ -121,14 +121,14 @@ PART
 			tankType = LFO
 			transform = Tail_Straight_A
 		}
-	
+
 		SUBTYPE
 		{
 			name = Straight_B_Structural
 			title = Straight B (Structural)
 			transform = Tail_Straight_B
 		}
-	
+
 		SUBTYPE
 		{
 			name = Straight_B_LF
@@ -136,7 +136,7 @@ PART
 			tankType = LiquidFuel
 			transform = Tail_Straight_B
 		}
-	
+
 		SUBTYPE
 		{
 			name = Straight_B_LFO
@@ -144,7 +144,7 @@ PART
 			tankType = LFO
 			transform = Tail_Straight_B
 		}
-	
+
 		SUBTYPE
 		{
 			name = Flat_Structural
@@ -153,7 +153,7 @@ PART
 			addedCost = 1170.0
 			transform = Tail_Flat
 		}
-	
+
 		SUBTYPE
 		{
 			name = Flat_LF
@@ -164,7 +164,7 @@ PART
 			tankType = LiquidFuel
 			transform = Tail_Flat
 		}
-	
+
 		SUBTYPE
 		{
 			name = Flat_LFO

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail.cfg
@@ -44,7 +44,7 @@ PART
     breakingForce = 2762
     breakingTorque = 2762
 	bulkheadProfiles = size3, srf
-    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold liquid payload structur tail tank tube
+    tags = ?lf ?lfo aircraft airlin airliner connect contain fuel fueltank freight hold liquid mono monopropellant payload propellant structur tail tank tube
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/A.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/A.cfg
@@ -48,7 +48,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = (air aircraft airliner freight payload support transport utility
+    tags = ?lf ?lfo (air aircraft airliner freight fuel fueltank liquid mono monopropellant payload support transport utility
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/A.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/A.cfg
@@ -33,7 +33,6 @@ PART
     title = HL Cargo Bay 2m
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -49,6 +48,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
+    tags = (air aircraft airliner freight payload support transport utility
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/A.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/A.cfg
@@ -55,7 +55,7 @@ PART
 		cube = A, 7.5,0.8124323,1.71704, 7.5,0.8124323,1.71704, 10.30376,1,0.08, 10.30376,1,0.08, 6.484376,0.8381144,1.006863, 6.484376,0.8381144,1.006863, 0,0,0, 3.2476,2,3.75
 		cube = B, 8.463417,0.8522912,5.663491, 8.46807,0.8512443,5.663491, 1.374695,0.9999587,0.6384315, 1.374695,0.9999589,0.6384315, 11.02926,0.7834924,4.279798, 11.02926,0.7994784,4.001437, 0,1.192093E-07,-0.2431879, 5.623348,2,4.236376
 	}
-	
+
 //	EFFECTS
 //    {
 //        doorMotor
@@ -80,21 +80,21 @@ PART
         startEventGUIName = Close cargo bay doors
         endEventGUIName = Open cargo bay doors
         actionGUIName = Toggle cargo bay doors
-		
+
         // availableInEVA = True
         // EVArange = 10
 
         // startRetractEffect = doorMotor
         // startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 1
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/A.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/A.cfg
@@ -48,7 +48,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = ?lf ?lfo (air aircraft airliner freight fuel fueltank liquid mono monopropellant payload support transport utility
+    tags = (air aircraft airliner cargo contain freight hold payload support transport utility
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/B.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/B.cfg
@@ -48,7 +48,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = ?lf ?lfo (air aircraft airliner freight fuel fueltank liquid mono monopropellant payload propellant support transport utility
+    tags = (air aircraft airliner cargo contain freight hold payload support transport utility
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/B.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/B.cfg
@@ -55,7 +55,7 @@ PART
 		cube = A, 15,0.8124323,1.71704, 15,0.8124323,1.71704, 10.30376,1,0.08, 10.30376,1,0.08, 12.968752,0.8381144,1.006863, 12.968752,0.8381144,1.006863, 0,0,0, 3.2476,4,3.75
 		cube = B, 16.85763,0.8524186,5.663491, 16.86779,0.8513737,5.663491, 1.374695,0.9999587,0.6423529, 1.374695,0.9999589,0.6423529, 22.15321,0.7831307,4.279798, 22.15321,0.7996733,4.001437, -2.384186E-07,0,-0.2431879, 5.623348,4,4.236376
 	}
-	
+
 //	EFFECTS
 //    {
 //        doorMotor
@@ -80,21 +80,21 @@ PART
         startEventGUIName = Close cargo bay doors
         endEventGUIName = Open cargo bay doors
         actionGUIName = Toggle cargo bay doors
-		
+
         // availableInEVA = True
 		// EVArange = 10
 
         // startRetractEffect = doorMotor
         // startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 2
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/B.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/B.cfg
@@ -48,7 +48,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = (air aircraft airliner freight payload support transport utility
+    tags = ?lf ?lfo (air aircraft airliner freight fuel fueltank liquid mono monopropellant payload propellant support transport utility
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/B.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/B.cfg
@@ -33,7 +33,6 @@ PART
     title = HL Cargo Bay 4m
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -49,6 +48,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
+    tags = (air aircraft airliner freight payload support transport utility
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/C.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/C.cfg
@@ -33,7 +33,6 @@ PART
     title = HL Cargo Bay 8m
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -49,13 +48,14 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
+    tags = (air aircraft airliner freight payload support transport utility
 
 	DRAG_CUBE
 	{
 		cube = A, 30,0.8124323,1.71704, 30,0.8124323,1.71704, 10.30376,1,0.08, 10.30376,1,0.08, 25.937504,0.8381144,1.006863, 25.937504,0.8381144,1.006863, 0,0,0, 3.2476,8,3.75
 		cube = B, 33.71094,0.8529904,5.663491, 33.71094,0.8556097,5.663491, 1.374695,0.9999587,0.6431373, 1.374695,0.9999589,0.6431373, 43.875,0.7870851,4.05363, 43.875,0.7919793,4.001437, -2.384186E-07,0,-0.2431879, 5.623348,8,4.236376
 	}
-	
+
 //	EFFECTS
 //    {
 //        doorMotor
@@ -80,21 +80,21 @@ PART
         startEventGUIName = Close cargo bay doors
         endEventGUIName = Open cargo bay doors
         actionGUIName = Toggle cargo bay doors
-		
+
         // availableInEVA = True
         // EVArange = 10
 
         // startRetractEffect = doorMotor
         // startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 4
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/C.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body_Cargo/C.cfg
@@ -48,7 +48,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = (air aircraft airliner freight payload support transport utility
+    tags = (air aircraft airliner cargo contain freight hold payload support transport utility
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Extension_A/Aero_HL_Extension_A.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Extension_A/Aero_HL_Extension_A.cfg
@@ -26,7 +26,6 @@ PART
     title = HL Fuselage Extension Nose
     manufacturer = Tetragon Projects
     description = Fuselage extensions mount. Attach this part to the side nodes available on every HL fuselage section, and continue building it along the new axis with various provided sections.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -42,6 +41,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
+    tags = affix aircraft airlin connect extend frame mount
 
 	MODULE
 	{
@@ -49,24 +49,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 580.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Extension_B/Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Extension_B/Universal.cfg
@@ -30,7 +30,6 @@ PART
     title = HL Universal Fuselage Extension
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -46,7 +45,8 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-	
+    tags = affix aircraft airlin connect extend frame mount
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -55,27 +55,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 440.0
-		
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = HL_Extension_B-STR
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = HL_Extension_B-LF
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 			transform = HL_Extension_B-LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Extension_B/Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Extension_B/Universal.cfg
@@ -45,7 +45,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = ?lf ?lfo affix aircraft airlin connect extend frame jet liquid mount plane
+    tags = ?lf ?lfo affix aircraft airlin connect extend frame fuel fueltank jet liquid mono monopropellant mount plane propellant
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Extension_B/Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Extension_B/Universal.cfg
@@ -45,7 +45,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = affix aircraft airlin connect extend frame mount
+    tags = ?lf ?lfo affix aircraft airlin connect extend frame jet liquid mount plane
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Extension_C/Aero_HL_Extension_C.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Extension_C/Aero_HL_Extension_C.cfg
@@ -42,7 +42,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = ?lf ?lfo affix aircraft airlin connect extend frame jet liquid mount plane
+    tags = ?lf ?lfo affix aircraft airlin connect extend frame jet liquid mono monopropellant mount plane propellant
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Extension_C/Aero_HL_Extension_C.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Extension_C/Aero_HL_Extension_C.cfg
@@ -42,7 +42,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
-    tags = affix aircraft airlin connect extend frame mount
+    tags = ?lf ?lfo affix aircraft airlin connect extend frame jet liquid mount plane
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Extension_C/Aero_HL_Extension_C.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Extension_C/Aero_HL_Extension_C.cfg
@@ -27,7 +27,6 @@ PART
     title = HL Fuselage Extension Adapter
     manufacturer = Tetragon Projects
     description = HL fuselage series features a variety of versatile modular parts for heavyweight aircraft and spaceplanes.
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -43,6 +42,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size3, srf
+    tags = affix aircraft airlin connect extend frame mount
 
 	MODULE
 	{
@@ -50,24 +50,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 240.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Aero_Intake_CLR/Aero_Intake_CLR.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Intake_CLR/Aero_Intake_CLR.cfg
@@ -39,6 +39,7 @@ PART
     maxTemp = 1800 // 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1
+    tags = aero breathe fligh inlet intake jet oxygen suck subsonic
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Aero_Intake_DSI/DSI.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Intake_DSI/DSI.cfg
@@ -45,6 +45,7 @@ PART
     maxTemp = 2000 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1, srf
+    tags = aero breathe fligh inlet intake jet oxygen suck supersonic
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Aero_Intake_DSI/DSI.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Intake_DSI/DSI.cfg
@@ -25,7 +25,7 @@ PART
     subcategory = 0
     title = DSI Diverterless Supersonic Inlet
     manufacturer = Tetragon Projects
-    description = This intake operates well in wide range of air speeds thanks to it's ususual geometry consisting of a bumped inner side and a forward-swept inlet cowl, which work together to divert boundary layer airflow away from the aircraft's engine while compressing the air to slow it down from supersonic speed. Effective Intake Area: 0.005
+    description = This intake operates well in wide range of air speeds thanks to it's unusual geometry consisting of a bumped inner side and a forward-swept inlet cowl, which work together to divert boundary layer airflow away from the aircraft's engine while compressing the air to slow it down from supersonic speed. Effective Intake Area: 0.005
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0

--- a/GameData/B9_Aerospace/Parts/Aero_Intake_DSI/DSIX.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Intake_DSI/DSIX.cfg
@@ -45,6 +45,7 @@ PART
     maxTemp = 2000 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1, srf
+    tags = aero breathe fligh inlet intake jet oxygen suck supersonic
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Aero_Intake_DSI/DSIX.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Intake_DSI/DSIX.cfg
@@ -25,7 +25,7 @@ PART
     subcategory = 0
     title = DSIX Diverterless Supersonic Inlet (Large)
     manufacturer = Tetragon Projects
-    description = This intake operates well in wide range of air speeds thanks to it's ususual geometry consisting of a bumped inner side and a forward-swept inlet cowl, which work together to divert boundary layer airflow away from the aircraft's engine while compressing the air to slow it down from supersonic speed. Effective Intake Area: 0.01
+    description = This intake operates well in wide range of air speeds thanks to it's unusual geometry consisting of a bumped inner side and a forward-swept inlet cowl, which work together to divert boundary layer airflow away from the aircraft's engine while compressing the air to slow it down from supersonic speed. Effective Intake Area: 0.01
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0

--- a/GameData/B9_Aerospace/Parts/Aero_Intake_Ramp/Mount.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Intake_Ramp/Mount.cfg
@@ -43,6 +43,7 @@ PART
     maxTemp = 2000 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1, srf
+    tags = (air aero affix anchor connect construct jet mount multi pair support
 
 	MODULE
 	{
@@ -50,24 +51,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 220.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Aero_Intake_Ramp/RBM.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Intake_Ramp/RBM.cfg
@@ -26,7 +26,6 @@ PART
     title = RBM Variable Geometry Intake
     manufacturer = Tetragon Projects
     description = This intake features the ramp that varies angle depending on your velocity to focus the oblique shock wave onto the intake lip. Operates well at supersonic speeds. Can be mounted on any surface of your craft. Features engine mount on the back side. Effective Intake Area: 0.0125
-
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
 
@@ -45,6 +44,7 @@ PART
     maxTemp = 2400 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1, srf
+    tags = aero breathe fligh inlet intake jet mount oxygen suck supersonic
 
     MODULE
     {
@@ -70,7 +70,7 @@ PART
         amount = 1.0 // Dummy value
         maxAmount = 1.0
     }
-	
+
 	MODULE
 	{
 		name = ModuleB9AnimateIntake

--- a/GameData/B9_Aerospace/Parts/Aero_Intake_Ramp/RNM.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_Intake_Ramp/RNM.cfg
@@ -44,6 +44,7 @@ PART
     maxTemp = 2400 // 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1, srf
+    tags = aero breathe fligh inlet intake jet mount oxygen suck supersonic
 
     MODULE
     {
@@ -69,7 +70,7 @@ PART
         amount = 1.0 // Dummy value
         maxAmount = 1.0
     }
-	
+
 	MODULE
 	{
 		name = ModuleB9AnimateIntake

--- a/GameData/B9_Aerospace/Parts/Aero_T2_Tail/Aero_T2_Tail.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_T2_Tail/Aero_T2_Tail.cfg
@@ -42,6 +42,7 @@ PART
     maxTemp = 2000 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size2
+    tags = affix aircraft airplane anchor base connect construct cover extend frame jet join plane scaffold support tail
 
 	MODULE
 	{
@@ -49,18 +50,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 1100.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_025m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_025m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_025m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_025m.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  0.1250,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -0.1250,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  0.0000,  0.6250,  0.0000,  0.0000, -1.0000
@@ -38,12 +38,13 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (more body fuel fueltank ?lf propellant separat support tank
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk1/body_mk1_section_025m
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 52
-		
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = body_mk1_section_025m_cs_flat
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			transform = body_mk1_section_025m_cs_tank
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			transform = body_mk1_section_025m_cs_tank
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
@@ -80,7 +81,7 @@ PART
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -88,14 +89,14 @@ PART
 		switcherDescription = Subtype
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Type A
 			transform = body_mk1_section_025m_a
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
@@ -103,7 +104,7 @@ PART
 			transform = body_mk1_section_025m_b
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_025m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_025m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = (more body fuel fueltank ?lf propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  0.2500,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -0.2500,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  0.0000,  0.6250,  0.0000,  0.0000, -1.0000
@@ -38,12 +38,13 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (more body fuel fueltank ?lf propellant separat support tank
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 104
-		
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = body_mk1_section_050m_cs_flat
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			transform = body_mk1_section_050m_cs_tank
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			transform = body_mk1_section_050m_cs_tank
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
@@ -80,7 +81,7 @@ PART
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -88,28 +89,28 @@ PART
 		switcherDescription = Subtype
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Type A
 			transform = body_mk1_section_050m_a
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
 			title = Type B
 			transform = body_mk1_section_050m_b
 		}
-		
+
 		SUBTYPE
 		{
 			name = C
 			title = Type C
 			transform = body_mk1_section_050m_c
 		}
-		
+
 		SUBTYPE
 		{
 			name = D
@@ -117,7 +118,7 @@ PART
 			transform = body_mk1_section_050m_d
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = (more body fuel fueltank ?lf propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m_payload_bay.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m_payload_bay.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top-int    =  0.0000,  0.2500,  0.0000,  0.0000, -1.0000,  0.0000, 0
 	node_stack_bottom-int =  0.0000, -0.2500,  0.0000,  0.0000,  1.0000,  0.0000, 0
 	node_stack_top        =  0.0000,  0.2500,  0.0000,  0.0000,  1.0000,  0.0000, 1
@@ -40,18 +40,19 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (stor contain equipment freight join load payload support transport unload
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk1/body_mk1_section_050m_payload_bay
 	}
-	
+
 	DRAG_CUBE
 	{
 		cube = A, 0.6944199,0.8117874,2.39759, 0.6944199,0.8159699,1.928497, 1.235175,0.9999753,0.09882361, 1.235175,0.9999753,0.09882361, 1.109286,0.7510164,1.235259, 1.109286,0.7469344,1.441135, 0,0,0, 2.458198,0.5,1.390863
 		cube = B, 0.6286621,0.7901942,0.642599, 0.6286621,0.790209,0.642599, 1.235175,0.9999753,0.09882361, 1.235175,0.9999753,0.09882361, 0.6262362,0.7850529,0.6254902, 0.6269515,0.7902019,0.6937255, 0,0,0, 1.25,0.5,1.25
 	}
-	
+
 	MODULE
 	{
 		name = ModuleAnimateGeneric
@@ -60,20 +61,20 @@ PART
 		endEventGUIName = Close
 		actionGUIName = Toggle bay doors
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 0.25
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  0.5000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -0.5000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  0.0000,  0.6250,  0.0000,  0.0000, -1.0000
@@ -38,12 +38,13 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (more body fuel fueltank ?lf propellant separat support tank
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 208
-		
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = body_mk1_section_100m_cs_flat
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			transform = body_mk1_section_100m_cs_tank
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			transform = body_mk1_section_100m_cs_tank
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
@@ -80,7 +81,7 @@ PART
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -88,28 +89,28 @@ PART
 		switcherDescription = Subtype
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Type A
 			transform = body_mk1_section_100m_a
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
 			title = Type B
 			transform = body_mk1_section_100m_b
 		}
-		
+
 		SUBTYPE
 		{
 			name = C
 			title = Type C
 			transform = body_mk1_section_100m_c
 		}
-		
+
 		SUBTYPE
 		{
 			name = D
@@ -117,7 +118,7 @@ PART
 			transform = body_mk1_section_100m_d
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = (more body fuel fueltank ?lf propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m_payload_bay.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m_payload_bay.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top-int    =  0.0000,  0.5000,  0.0000,  0.0000, -1.0000,  0.0000, 0
 	node_stack_bottom-int =  0.0000, -0.5000,  0.0000,  0.0000,  1.0000,  0.0000, 0
 	node_stack_top        =  0.0000,  0.5000,  0.0000,  0.0000,  1.0000,  0.0000, 1
@@ -40,18 +40,19 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (stor contain equipment freight join load payload support transport unload
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk1/body_mk1_section_100m_payload_bay
 	}
-	
+
 	DRAG_CUBE
 	{
 		cube = A, 1.331667,0.803358,1.30326, 1.331667,0.8040609,1.325349, 1.235175,0.9999838,0.09882358, 1.235175,0.9999838,0.09882358, 2.281769,0.7619675,1.1756, 2.281769,0.7637416,1.37953, 0,0,0, 2.616366,1,1.329479
 		cube = B, 1.251221,0.7870855,0.642599, 1.251221,0.7874961,0.642599, 1.235175,0.9999838,0.09882358, 1.235175,0.9999838,0.09882358, 1.246363,0.7914118,0.6254902, 1.248437,0.7902553,0.7790197, 0,0,0, 1.25,1,1.25
 	}
-	
+
 	MODULE
 	{
 		name = ModuleAnimateGeneric
@@ -60,20 +61,20 @@ PART
 		endEventGUIName = Close
 		actionGUIName = Toggle bay doors
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 0.5
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = (more body fuel fueltank ?lf propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  1.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -1.0000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  0.0000,  0.6250,  0.0000,  0.0000, -1.0000
@@ -38,12 +38,13 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (more body fuel fueltank ?lf propellant separat support tank
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 416
-		
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = body_mk1_section_200m_cs_flat
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			transform = body_mk1_section_200m_cs_tank
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			transform = body_mk1_section_200m_cs_tank
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
@@ -80,7 +81,7 @@ PART
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -88,28 +89,28 @@ PART
 		switcherDescription = Subtype
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Type A
 			transform = body_mk1_section_200m_a
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
 			title = Type B
 			transform = body_mk1_section_200m_b
 		}
-		
+
 		SUBTYPE
 		{
 			name = C
 			title = Type C
 			transform = body_mk1_section_200m_c
 		}
-		
+
 		SUBTYPE
 		{
 			name = D
@@ -117,7 +118,7 @@ PART
 			transform = body_mk1_section_200m_d
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m_payload_bay.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m_payload_bay.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top-int    =  0.0000,  1.0000,  0.0000,  0.0000, -1.0000,  0.0000, 0
 	node_stack_bottom-int =  0.0000, -1.0000,  0.0000,  0.0000,  1.0000,  0.0000, 0
 	node_stack_top        =  0.0000,  1.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
@@ -40,18 +40,19 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (stor contain equipment freight join load payload support transport unload
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk1/body_mk1_section_200m_payload_bay
 	}
-	
+
 	DRAG_CUBE
 	{
 		cube = A, 2.671875,0.8021024,1.325349, 2.671875,0.8056404,1.325349, 1.235175,0.9999993,0.1035295, 1.235175,0.9999993,0.1035295, 4.585854,0.7611309,1.1756, 4.585854,0.7650576,1.37953, 0,0,0, 2.616366,2,1.329479
 		cube = B, 2.5,0.7876647,0.642599, 2.5,0.7876338,0.642599, 1.235175,0.9999993,0.1035295, 1.235175,0.9999993,0.1035295, 2.5,0.7907729,0.6425492, 2.50647,0.7874551,0.7790198, 0,0,0, 1.25,2,1.25
 	}
-	
+
 	MODULE
 	{
 		name = ModuleAnimateGeneric
@@ -60,20 +61,20 @@ PART
 		endEventGUIName = Close
 		actionGUIName = Toggle bay doors
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 1.0
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_400m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_400m.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  2.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -2.0000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  0.0000,  0.6250,  0.0000,  0.0000, -1.0000
@@ -38,12 +38,13 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (more body fuel fueltank ?lf propellant separat support tank
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk1/body_mk1_section_400m
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 832
-		
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = body_mk1_section_400m_cs_flat
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			transform = body_mk1_section_400m_cs_tank
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			transform = body_mk1_section_400m_cs_tank
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
@@ -80,7 +81,7 @@ PART
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -88,28 +89,28 @@ PART
 		switcherDescription = Subtype
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Type A
 			transform = body_mk1_section_400m_a
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
 			title = Type B
 			transform = body_mk1_section_400m_b
 		}
-		
+
 		SUBTYPE
 		{
 			name = C
 			title = Type C
 			transform = body_mk1_section_400m_c
 		}
-		
+
 		SUBTYPE
 		{
 			name = D
@@ -117,7 +118,7 @@ PART
 			transform = body_mk1_section_400m_d
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_400m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_400m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_400m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk1/body_mk1_section_400m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = (more body fuel fueltank ?lf propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_bicoupler.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_bicoupler.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top      =  0.0000,  0.5000,  0.0000,  0.0000,  1.0000, 0.0000, 1
 	node_stack_bottom01 =  0.6250, -0.5000,  0.0000,  0.0000, -1.0000, 0.0000, 1
 	node_stack_bottom02 = -0.6250, -0.5000,  0.0000,  0.0000, -1.0000, 0.0000, 1
@@ -40,43 +40,44 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2, size1
-	
+	tags = (bi adapter break connect decouple extend mount node
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_bicoupler
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 415
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_long.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_long.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top01  = 0.0000,  2.0000,  0.0000,  0.0000,  1.0000, 0.0000, 1
 	node_stack_top02  = 0.0000,  2.0000, -0.1050,  0.0000,  1.0000, 0.0000, 1
 	node_stack_bottom = 0.0000, -2.0000,  0.0000,  0.0000, -1.0000, 0.0000, 1
@@ -39,56 +39,57 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2, size1
-	
+	tags = adapter break connect extend mount node
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_long
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 1250
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-		
+
 		SUBTYPE
 		{
 			name = Centered
 			transform = body_mk2_adapter_125m_long
 			node = top01
 		}
-		
+
 		SUBTYPE
 		{
 			name = Offset
@@ -96,7 +97,7 @@ PART
 			node = top02
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_short.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_short.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  0.5000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -0.5000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000, -0.5000,  0.0000,  0.0000, -1.0000,  0.0000
@@ -38,43 +38,44 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2, size1
-	
+	tags = adapter break connect extend mount node
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_short
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 310
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_shroud_full.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_shroud_full.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  1.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -1.0000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  1.0000,  0.0000,  0.0000,  1.0000,  0.0000
@@ -38,43 +38,44 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = mk2
-	
+	tags = adapter affix bind body connect extend mount multi node shroud support
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_shroud_full
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 830
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_shroud_half.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_shroud_half.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  0.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -0.5000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000, -0.5000,  0.0000,  0.0000, -1.0000,  0.0000
@@ -38,43 +38,44 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2, size1
-	
+	tags = adapter affix bind body connect extend mount multi node shroud support
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_125m_shroud_half
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 168
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_250m_long.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_250m_long.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top01  =  0.0000,  2.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_top02  =  0.0000,  2.0000, -0.5200,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -2.0000,  0.0000,  0.0000, -1.0000,  0.0000, 2
@@ -39,56 +39,57 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2, size2
-	
+	tags = adapter break connect extend mount node
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_250m_long
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 2500
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-		
+
 		SUBTYPE
 		{
 			name = Centered
 			transform = body_mk2_adapter_250m_long
 			node = top01
 		}
-		
+
 		SUBTYPE
 		{
 			name = Offset
@@ -96,7 +97,7 @@ PART
 			node = top02
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_250m_short.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_250m_short.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  0.5000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -0.5000,  0.0000,  0.0000, -1.0000,  0.0000, 2
 	node_attach       =  0.0000, -0.5000,  0.0000,  0.0000, -1.0000,  0.0000
@@ -38,43 +38,44 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	
+	tags = adapter break connect extend mount node
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_adapter_250m_short
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 625
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_long.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_long.cfg
@@ -37,7 +37,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = ?lf ?lfo (more body fuel fueltank propellant tail tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant tail tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_long.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_long.cfg
@@ -37,7 +37,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = (more body fuel fueltank ?lf propellant tail tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant tail tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_long.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_long.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_bottom = 0.0000, -1.5000, 0.0000, 0.0000, -1.0000, 0.0000, 1
 	node_attach       = 0.0000, -1.5000, 0.0000, 0.0000, -1.0000, 0.0000
 
@@ -37,62 +37,63 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (more body fuel fueltank ?lf propellant tail tank
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_long
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 310
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-		
+
 		SUBTYPE
 		{
 			name = Centered
 			transform = body_mk2_nosecone_125m_long
 		}
-		
+
 		SUBTYPE
 		{
 			name = Offset
 			transform = body_mk2_nosecone_125m_long_offset
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_short.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_short.cfg
@@ -37,7 +37,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = ?lf ?lfo (more body fuel fueltank propellant tail tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant tail tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_short.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_short.cfg
@@ -37,7 +37,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	tags = (more body fuel fueltank ?lf propellant tail tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant tail tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_short.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_short.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_bottom = 0.0000, -0.5000, 0.0000, 0.0000, -1.0000, 0.0000, 1
 	node_attach       = 0.0000, -0.5000, 0.0000, 0.0000, -1.0000, 0.0000
 
@@ -37,62 +37,63 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, size1
-	
+	tags = (more body fuel fueltank ?lf propellant tail tank
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_125m_short
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 155
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-		
+
 		SUBTYPE
 		{
 			name = Centered
 			transform = body_mk2_nosecone_125m_short
 		}
-		
+
 		SUBTYPE
 		{
 			name = Offset
 			transform = body_mk2_nosecone_125m_short_offset
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_long.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_long.cfg
@@ -37,7 +37,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	tags = ?lf ?lfo (more body fuel fueltank propellant tail tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant tail tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_long.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_long.cfg
@@ -37,7 +37,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	tags = (more body fuel fueltank ?lf propellant tail tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant tail tank
 
 	MODEL
 	{

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_long.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_long.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_bottom = 0.0000, -2.0000, 0.0000, 0.0000, -1.0000, 0.0000, 1
 	node_attach       = 0.0000, -2.0000, 0.0000, 0.0000, -1.0000, 0.0000
 
@@ -37,62 +37,63 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	
+	tags = (more body fuel fueltank ?lf propellant tail tank
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_long
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 941
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-		
+
 		SUBTYPE
 		{
 			name = Centered
 			transform = body_mk2_nosecone_direct_long
 		}
-		
+
 		SUBTYPE
 		{
 			name = Offset
 			transform = body_mk2_nosecone_direct_long_offset
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_short.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_short.cfg
@@ -5,7 +5,7 @@ PART
     author = bac9
     scale = 1
     rescaleFactor = 1
-    
+
     node_stack_bottom = 0.0000, -0.7500, 0.0000, 0.0000, -1.0000, 0.0000, 1
     node_attach       = 0.0000, -0.7500, 0.0000, 0.0000, -1.0000, 0.0000
 
@@ -37,62 +37,63 @@ PART
     emissiveConstant = 0.8
     fuelCrossFeed = True
     bulkheadProfiles = srf, mk2
-    
+	tags = (more body fuel fueltank ?lf propellant tail tank
+
     MODEL
     {
         model = B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_short
     }
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 336
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-		
+
 		SUBTYPE
 		{
 			name = Centered
 			transform = body_mk2_nosecone_direct_short
 		}
-		
+
 		SUBTYPE
 		{
 			name = Offset
 			transform = body_mk2_nosecone_direct_short_offset
 		}
 	}
-    
+
     MODULE:NEEDS[!FerramAerospaceResearch]
     {
         name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_short.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_short.cfg
@@ -37,7 +37,7 @@ PART
     emissiveConstant = 0.8
     fuelCrossFeed = True
     bulkheadProfiles = srf, mk2
-	tags = (more body fuel fueltank ?lf propellant tail tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant tail tank
 
     MODEL
     {

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_short.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_nosecone_direct_short.cfg
@@ -37,7 +37,7 @@ PART
     emissiveConstant = 0.8
     fuelCrossFeed = True
     bulkheadProfiles = srf, mk2
-	tags = ?lf ?lfo (more body fuel fueltank propellant tail tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant tail tank
 
     MODEL
     {

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	tags = (more body fuel fueltank ?lf propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
 
 
 	MODEL

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  0.2500,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -0.2500,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  0.0000,  0.7300,  0.0000,  0.0000, -1.0000
@@ -38,43 +38,45 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	
+	tags = (more body fuel fueltank ?lf propellant separat support tank
+
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 200
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -82,14 +84,14 @@ PART
 		switcherDescription = Subtype
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Type A
 			transform = body_mk2_section_0m_a
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
@@ -97,7 +99,7 @@ PART
 			transform = body_mk2_section_0m_b
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant separat support tank
 
 
 	MODEL

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m_sas.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m_sas.cfg
@@ -5,7 +5,7 @@ PART
     author = bac9
     scale = 1
     rescaleFactor = 1
-    
+
     node_stack_top    =  0.0000,  0.2500,  0.0000,  0.0000,  1.0000,  0.0000, 1
     node_stack_bottom =  0.0000, -0.2500,  0.0000,  0.0000, -1.0000,  0.0000, 1
 
@@ -36,12 +36,14 @@ PART
     emissiveConstant = 0.8
     fuelCrossFeed = True
     bulkheadProfiles = mk2
-    
+	tags = (core command control pilot probe sas torque
+
+
     MODEL
     {
         model = B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m_sas
     }
-    
+
     MODULE:NEEDS[!FerramAerospaceResearch]
     {
         name = ModuleLiftingSurface
@@ -50,26 +52,26 @@ PART
         dragAtMaxAoA = 0.3
         dragAtMinAoA = 0.1
     }
-    
+
 	MODULE
 	{
 		name = ModuleCommand
 		minimumCrew = 0
-		
+
 		RESOURCE
 		{
 			name = ElectricCharge
 			rate = 0.05
 		}
 	}
-	
+
 	RESOURCE
 	{
 		name = ElectricCharge
 		amount = 250
 		maxAmount = 250
 	}
-	
+
 	MODULE
 	{
 		name = ModuleReactionWheel
@@ -82,7 +84,7 @@ PART
 			rate = 0.5
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSAS

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  0.5000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -0.5000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  0.0000,  0.7300,  0.0000,  0.0000, -1.0000
@@ -38,43 +38,45 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	
+	tags = (more body fuel fueltank ?lf propellant separat support tank
+
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 400
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -82,14 +84,14 @@ PART
 		switcherDescription = Subtype
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Type A
 			transform = body_mk2_section_1m_a
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
@@ -97,7 +99,7 @@ PART
 			transform = body_mk2_section_1m_b
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	tags = (more body fuel fueltank ?lf propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
 
 
 	MODEL

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant separat support tank
 
 
 	MODEL

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m_payload_bay.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m_payload_bay.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top-int    =  0.0000,  0.5000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_stack_bottom-int =  0.0000, -0.5000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_top        =  0.0000,  0.5000,  0.0000,  0.0000,  1.0000,  0.0000, 1
@@ -40,18 +40,19 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	
+	tags = (stor contain equipment freight join load payload support transport unload
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_section_1m_payload_bay
 	}
-	
+
 	DRAG_CUBE
 	{
 		cube = A, 2.027251,0.7773546,2.004966, 2.027251,0.7774792,2.070168, 2.494621,0.971287,0.16, 2.494621,0.971287,0.16, 3.876745,0.7686724,2.117149, 3.876745,0.7614694,2.056161, 0,0,0, 3.956637,1.000000,2.021699
 		cube = B, 1.50293,0.5521753,1.344707, 1.50293,0.5517625,1.344707, 2.494621,0.971287,0.16, 2.494621,0.971287,0.16, 2.514649,0.9086898,0.7000076, 2.514649,0.9077584,0.7000076, 0,0,0, 2.500000,1.000000,1.500000
 	}
-	
+
 	MODULE
 	{
 		name = ModuleAnimateGeneric
@@ -60,20 +61,20 @@ PART
 		endEventGUIName = Close
 		actionGUIName = Toggle bay doors
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 0.5
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	tags = (more body fuel fueltank ?lf propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
 
 
 	MODEL

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top    =  0.0000,  1.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_bottom =  0.0000, -1.0000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_attach       =  0.0000,  0.0000,  0.7300,  0.0000,  0.0000, -1.0000
@@ -38,43 +38,45 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	
+	tags = (more body fuel fueltank ?lf propellant separat support tank
+
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Type
 		baseVolume = 800
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
@@ -82,28 +84,28 @@ PART
 		switcherDescription = Subtype
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Type A
 			transform = body_mk2_section_2m_a
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
 			title = Type B
 			transform = body_mk2_section_2m_b
 		}
-		
+
 		SUBTYPE
 		{
 			name = C
 			title = Type C
 			transform = body_mk2_section_2m_c
 		}
-		
+
 		SUBTYPE
 		{
 			name = D
@@ -111,7 +113,7 @@ PART
 			transform = body_mk2_section_2m_d
 		}
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m.cfg
@@ -38,7 +38,7 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	tags = ?lf ?lfo (more body fuel fueltank propellant separat support tank
+	tags = ?lf ?lfo (more body fuel fueltank liquid mono monopropellant propellant separat support tank
 
 
 	MODEL

--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m_payload_bay.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m_payload_bay.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_top-int    =  0.0000,  1.0000,  0.0000,  0.0000, -1.0000,  0.0000, 1
 	node_stack_bottom-int =  0.0000, -1.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
 	node_stack_top        =  0.0000,  1.0000,  0.0000,  0.0000,  1.0000,  0.0000, 1
@@ -40,18 +40,19 @@ PART
 	emissiveConstant = 0.8
 	fuelCrossFeed = True
 	bulkheadProfiles = srf, mk2
-	
+	tags = (stor contain equipment freight join load payload support transport unload
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2/body_mk2_section_2m_payload_bay
 	}
-	
+
 	DRAG_CUBE
 	{
 		cube = A, 4.042144,0.7772319,2.004966, 4.042144,0.7773817,2.070168, 2.494621,0.971287,0.1639216, 2.494621,0.971287,0.1639216, 7.694771,0.7687904,2.117149, 7.694771,0.767275,2.056161, 0,0,0, 3.956637,2.000000,2.0217
 		cube = B, 3,0.554144,1.344706, 3,0.5535938,1.344706, 2.494621,0.971287,0.1639216, 2.494621,0.971287,0.1639216, 5.004883,0.9087893,0.7000076, 5.004883,0.9078582,0.7000076, 0,0,0, 2.500000,2.000000,1.500000
 	}
-	
+
 	MODULE
 	{
 		name = ModuleAnimateGeneric
@@ -60,20 +61,20 @@ PART
 		endEventGUIName = Close
 		actionGUIName = Toggle bay doors
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 1
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_bottom = 0.0000, -1.2500, 0.0000, 0.0000, -1.0000, 0.0000
 
 	TechRequired = highAltitudeFlight
@@ -37,37 +37,38 @@ PART
 	vesselType = Ship
 	CrewCapacity = 1
 	bulkheadProfiles = mk2
-	
+	tags = ?eva ?iva capsule command control pilot pod sas view
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a
 	}
-	
+
 	INTERNAL
 	{
 		name = body_mk2_cockpit_a_iva
 	}
-	
+
 	RESOURCE
 	{
 		name = ElectricCharge
 		amount = 150
 		maxAmount = 150
 	}
-	
+
 	RESOURCE
 	{
 		name = MonoPropellant
 		amount = 15
 		maxAmount = 15
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCommand
 		minimumCrew = 1
 	}
-	
+
 	MODULE
 	{
 		name = ModuleReactionWheel
@@ -81,7 +82,7 @@ PART
 			rate = 0.5
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleScienceExperiment
@@ -97,7 +98,7 @@ PART
 		usageReqMaskInternal = 5
 		usageReqMaskExternal = -1
 	}
-	
+
 	MODULE
 	{
 		name = ModuleScienceContainer
@@ -106,7 +107,7 @@ PART
 		evaOnlyStorage = True
 		storageRange = 3.0
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a_intake.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a_intake.cfg
@@ -5,7 +5,7 @@ PART
 	author = bac9
 	scale = 1
 	rescaleFactor = 1
-	
+
 	node_stack_bottom = 0.0000, -1.2500, 0.0000, 0.0000, -1.0000, 0.0000
 
 	TechRequired = highAltitudeFlight
@@ -37,37 +37,38 @@ PART
 	vesselType = Ship
 	CrewCapacity = 1
 	bulkheadProfiles = mk2
-	
+	tags = (air ?eva ?iva breathe capsule command control intake pilot pod sas view
+
 	MODEL
 	{
 		model = B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a_intake
 	}
-	
+
 	INTERNAL
 	{
 		name = body_mk2_cockpit_a_iva
 	}
-	
+
 	RESOURCE
 	{
 		name = ElectricCharge
 		amount = 150
 		maxAmount = 150
 	}
-	
+
 	RESOURCE
 	{
 		name = MonoPropellant
 		amount = 15
 		maxAmount = 15
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCommand
 		minimumCrew = 1
 	}
-	
+
 	MODULE
 	{
 		name = ModuleReactionWheel
@@ -81,7 +82,7 @@ PART
 			rate = 0.5
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleResourceIntake
@@ -99,7 +100,7 @@ PART
 			key = 5 0.01 0 0
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleScienceExperiment
@@ -115,7 +116,7 @@ PART
 		usageReqMaskInternal = 5
 		usageReqMaskExternal = -1
 	}
-	
+
 	MODULE
 	{
 		name = ModuleScienceContainer
@@ -124,7 +125,7 @@ PART
 		evaOnlyStorage = True
 		storageRange = 3.0
 	}
-	
+
 	MODULE:NEEDS[!FerramAerospaceResearch]
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Cargo_M2_Adapter/Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Cargo_M2_Adapter/Adapter.cfg
@@ -45,6 +45,7 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size2
+    tags = (stor adapter cargo contain payload transport
 
 	MODULE
 	{
@@ -52,18 +53,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 720.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Cargo_M2_Adapter/Separator.cfg
+++ b/GameData/B9_Aerospace/Parts/Cargo_M2_Adapter/Separator.cfg
@@ -46,25 +46,26 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size2
-	
+    tags = (stor adapter cargo contain payload separat transport
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 580.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Cargo_M2_Body/Doors.cfg
+++ b/GameData/B9_Aerospace/Parts/Cargo_M2_Body/Doors.cfg
@@ -49,7 +49,8 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size2
-	
+    tags = (stor cargo contain payload transport
+
 	DRAG_CUBE
 	{
 		cube = A, 2.502441,0.6755488,0.9800251, 2.502441,0.6755488,0.9800251, 3.988171,0.9576434,0.2494118, 3.988171,0.9576434,0.2494118, 3.546875,0.9191472,0.4658824, 3.546875,0.9191472,0.4658824, 0,0,0, 1.767767,2,2.5
@@ -80,21 +81,21 @@ PART
         startEventGUIName = Close cargo bay doors
         endEventGUIName = Open cargo bay doors
         actionGUIName = Toggle cargo bay doors
-		
+
         // availableInEVA = True
         // EVArange = 10
 
         // startRetractEffect = doorMotor
         // startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 1
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int

--- a/GameData/B9_Aerospace/Parts/Cockpit_D25/Cockpit_D25.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_D25/Cockpit_D25.cfg
@@ -41,6 +41,7 @@ PART
     breakingTorque = 256
     maxTemp = 2000 // 3400
 	bulkheadProfiles = size3
+    tags= (core command control probe react sas torque
 
     vesselType = Probe
 

--- a/GameData/B9_Aerospace/Parts/Cockpit_HL/HL_Aero_Cockpit.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_HL/HL_Aero_Cockpit.cfg
@@ -39,6 +39,7 @@ PART
     breakingTorque = 400
     maxTemp = 2700 // = 3400
 	bulkheadProfiles = size3
+    tags= ?eva ?iva capsule command control kerbal pilot react sas view
 
     stagingIcon = COMMAND_POD
     vesselType = Ship

--- a/GameData/B9_Aerospace/Parts/Cockpit_M27/Cockpit_M27.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_M27/Cockpit_M27.cfg
@@ -40,6 +40,7 @@ PART
     breakingTorque = 256
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size2
+    tags= ?eva ?iva capsule command control kerbal pilot react sas torque view
 
     stagingIcon = COMMAND_POD
     vesselType = Ship

--- a/GameData/B9_Aerospace/Parts/Cockpit_MK1_Junction/Cockpit_MK1_Junction.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_MK1_Junction/Cockpit_MK1_Junction.cfg
@@ -43,6 +43,7 @@ PART
     fuelCrossFeed = True
     CoMOffset = 0.0, 0.625, 0.0
 	bulkheadProfiles = size1, srf
+    tags = affix base connect construct mount multi secure
 
 	MODULE
 	{
@@ -50,24 +51,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 940.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Cockpit_MK5/Cockpit_MK5.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_MK5/Cockpit_MK5.cfg
@@ -37,6 +37,7 @@ PART
     breakingTorque = 300
     maxTemp = 2500 // = 3400
 	bulkheadProfiles = size2
+    tags= ?eva ?iva capsule command control kerbal pilot react sas view
 
     stagingIcon = COMMAND_POD
     vesselType = Ship

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2/Cockpit_S2.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2/Cockpit_S2.cfg
@@ -39,6 +39,7 @@ PART
     breakingTorque = 400
     maxTemp = 2500 // = 3400
 	bulkheadProfiles = size2
+    tags= ?eva ?iva capsule command control kerbal pilot react sas view
 
     stagingIcon = COMMAND_POD
     vesselType = Ship

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Adapter/Cockpit_S2_Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Adapter/Cockpit_S2_Adapter.cfg
@@ -40,6 +40,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2
+    tags = adapter connect cover fuel fueltank hold  heat mount protect shield therm thermo
 
 	MODULE
 	{
@@ -47,24 +48,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 400.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Adapter/Cockpit_S2_Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Adapter/Cockpit_S2_Adapter.cfg
@@ -40,7 +40,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2
-    tags = ?lf ?lfo adapter connect cover fuel fueltank hold  heat mount propellant protect shield therm thermo
+    tags = ?lf ?lfo adapter connect cover fuel fueltank hold heat liquid mono monopropellant mount propellant protect shield therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Adapter/Cockpit_S2_Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Adapter/Cockpit_S2_Adapter.cfg
@@ -40,7 +40,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2
-    tags = adapter connect cover fuel fueltank hold  heat mount protect shield therm thermo
+    tags = ?lf ?lfo adapter connect cover fuel fueltank hold  heat mount propellant protect shield therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/05m-SAS.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/05m-SAS.cfg
@@ -42,6 +42,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2
+    tags = advanced control fly react rotate sas torque translate
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/05m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/05m-Universal.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = contain fuel fueltank hold protect shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/05m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/05m-Universal.cfg
@@ -43,6 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = contain fuel fueltank hold protect shield structur therm thermo
 
 	MODULE
 	{
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 374.0
-	
+
 		SUBTYPE
 		{
 			name = Structure
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/05m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/05m-Universal.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo contain fuel fueltank hold protect propellant shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/1m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/1m-Universal.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = contain fuel fueltank hold protect rcs shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold protect propellant rcs shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/1m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/1m-Universal.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo contain fuel fueltank hold protect propellant rcs shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant protect propellant rcs shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/1m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/1m-Universal.cfg
@@ -43,6 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = contain fuel fueltank hold protect rcs shield structur therm thermo
 
 	MODULE
 	{
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 750.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/2m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/2m-Universal.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = contain fuel fueltank hold protect shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/2m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/2m-Universal.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo contain fuel fueltank hold protect propellant shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/2m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/2m-Universal.cfg
@@ -43,6 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = contain fuel fueltank hold protect shield structur therm thermo
 
 	MODULE
 	{
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 1500.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/6m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/6m-Universal.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = contain fuel fueltank hold protect shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/6m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/6m-Universal.cfg
@@ -43,7 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo contain fuel fueltank hold liquid protect propellant shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/6m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body/6m-Universal.cfg
@@ -43,6 +43,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = contain fuel fueltank hold protect shield structur therm thermo
 
 	MODULE
 	{
@@ -52,27 +53,27 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 4500.0
-	
+
 		SUBTYPE
 		{
 			name = Structure
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-2m.cfg
@@ -46,7 +46,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo cargo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
+    tags = (stor cargo contain hold payload protect shield structur therm thermo
 
     DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-2m.cfg
@@ -46,7 +46,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = cargo contain fuel fueltank hold protect shield structur therm thermo
+    tags = ?lf ?lfo cargo contain fuel fueltank hold protect propellant shield structur therm thermo
 
     DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-2m.cfg
@@ -46,13 +46,14 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = cargo contain fuel fueltank hold protect shield structur therm thermo
 
-	DRAG_CUBE
+    DRAG_CUBE
 	{
 		cube = A, 4.339599,0.7966696,0.7804267, 4.339599,0.7966696,0.7804267, 4.336627,1,0.1035294, 4.336627,1,0.1035294, 4.77645,0.8530095,0.7790797, 4.77645,0.8530095,0.7790797, 0,0,0, 2.38453,2,2.165063
 		cube = B, 5.102829,0.843582,4.066268, 5.106752,0.8449776,4.066268, 1.113743,0.9996669,0.6470588, 1.113743,0.9996668,0.6470588, 8.079367,0.8022316,2.114256, 8.079367,0.8171406,2.493738, 0,0,-0.1998667, 4.049584,2,2.564797
 	}
-	
+
 //	EFFECTS
 //    {
 //        doorMotor
@@ -77,27 +78,27 @@ PART
         startEventGUIName = Close cargo bay doors
         endEventGUIName = Open cargo bay doors
         actionGUIName = Toggle cargo bay doors
-		
+
         // availableInEVA = True
         // EVArange = 10
 
         // startRetractEffect = doorMotor
         // startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 1
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-    
+
 	MODULE
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-2m.cfg
@@ -46,7 +46,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo cargo contain fuel fueltank hold protect propellant shield structur therm thermo
+    tags = ?lf ?lfo cargo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
 
     DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-6m.cfg
@@ -46,7 +46,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = cargo contain fuel fueltank hold protect shield structur therm thermo
+    tags = ?lf ?lfo cargo contain fuel fueltank hold protect propellant shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-6m.cfg
@@ -46,7 +46,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo cargo contain fuel fueltank hold protect propellant shield structur therm thermo
+    tags = ?lf ?lfo cargo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-6m.cfg
@@ -46,7 +46,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo cargo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
+    tags = (stor cargo contain hold payload protect shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2-6m.cfg
@@ -46,13 +46,14 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = cargo contain fuel fueltank hold protect shield structur therm thermo
 
 	DRAG_CUBE
 	{
 		cube = A, 13.07813,0.7962387,0.7702913, 13.07813,0.7962556,0.7702913, 4.336627,1,0.0972549, 4.336627,1,0.0972549, 14.20313,0.8538352,0.7605302, 14.20313,0.8542588,0.7605302, 0,0,0, 2.38453,6,2.165063
 		cube = B, 15.30396,0.844156,4.066268, 15.30396,0.8470482,4.066268, 1.113743,0.9996669,0.6564706, 1.113743,0.9996668,0.6564706, 24.12817,0.8041823,2.103414, 24.12817,0.8339547,2.493738, 0,0,0, 4.049584,6,2.564797
 	}
-	
+
 //    EFFECTS
 //    {
 //        doorMotor
@@ -77,27 +78,27 @@ PART
         startEventGUIName = Close cargo bay doors
         endEventGUIName = Open cargo bay doors
         actionGUIName = Toggle cargo bay doors
-		
+
         // availableInEVA = True
         // EVArange = 10
 
         // startRetractEffect = doorMotor
         // startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 3
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-	
+
 	MODULE
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-2m.cfg
@@ -49,13 +49,14 @@ PART
     breakingForce = 8460
     breakingTorque = 8460
 	bulkheadProfiles = size2, srf
+    tags = cargo contain fuel fueltank hold protect shield structur therm thermo
 
 	DRAG_CUBE
 	{
 		cube = A, 6.34375,0.7574509,2.033812, 6.34375,0.7414476,2.033812, 11.35694,1,0.09882353, 11.35694,1,0.09882353, 9.74192,0.8679241,1.280044, 9.74192,0.8677279,1.280044, 0,0,0, 4.88453,2,3.165063
 		cube = B, 7.680605,0.8126789,3.356, 7.710963,0.8141258,3.386509, 1.882203,0.9957935,0.6470597, 1.882203,0.9957294,0.6470597, 13.65887,0.8381687,3.004456, 13.65887,0.835345,3.823853, 0,0,0, 7.579819,2,3.896986
 	}
-	
+
 //    EFFECTS
 //    {
 //        doorMotor
@@ -80,27 +81,27 @@ PART
         startEventGUIName = Close cargo bay doors
         endEventGUIName = Open cargo bay doors
         actionGUIName = Toggle cargo bay doors
-		
+
         // availableInEVA = True
         // EVArange = 10
 
         // startRetractEffect = doorMotor
         // startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 1
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-	
+
 	MODULE
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-2m.cfg
@@ -49,7 +49,7 @@ PART
     breakingForce = 8460
     breakingTorque = 8460
 	bulkheadProfiles = size2, srf
-    tags = cargo contain fuel fueltank hold protect shield structur therm thermo
+    tags = ?lf ?lfo cargo contain fuel fueltank hold protect propellant shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-2m.cfg
@@ -49,7 +49,7 @@ PART
     breakingForce = 8460
     breakingTorque = 8460
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo cargo contain fuel fueltank hold protect propellant shield structur therm thermo
+    tags = ?lf ?lfo cargo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-2m.cfg
@@ -49,7 +49,7 @@ PART
     breakingForce = 8460
     breakingTorque = 8460
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo cargo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
+    tags = (stor cargo contain hold payload protect shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-6m.cfg
@@ -49,7 +49,7 @@ PART
     breakingForce = 940
     breakingTorque = 940
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo cargo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
+    tags = (stor cargo contain hold payload protect shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-6m.cfg
@@ -49,7 +49,7 @@ PART
     breakingForce = 940
     breakingTorque = 940
 	bulkheadProfiles = size2, srf
-    tags = cargo contain fuel fueltank hold protect shield structur therm thermo
+    tags = ?lf ?lfo cargo contain fuel fueltank hold protect propellant shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-6m.cfg
@@ -49,13 +49,14 @@ PART
     breakingForce = 940
     breakingTorque = 940
 	bulkheadProfiles = size2, srf
+    tags = cargo contain fuel fueltank hold protect shield structur therm thermo
 
 	DRAG_CUBE
 	{
 		cube = A, 19.0313,0.7574509,2.033812, 19.0313,0.7414476,2.033812, 11.35694,1,0.09882353, 11.35694,1,0.09882353, 29.2257,0.8679241,1.280044, 29.2257,0.8677279,1.280044, 0,0,0, 4.88453,6,3.165063
 		cube = B, 23.20313,0.8108335,3.386509, 23.20313,0.8129982,3.386509, 1.882203,0.9957935,0.6564709, 1.882203,0.9957294,0.6564709, 41.34645,0.8381141,3.004456, 41.34645,0.8352405,3.823853, 0,0,0, 7.579819,6,3.896986
 	}
-	
+
 //	EFFECTS
 //    {
 //        doorMotor
@@ -80,27 +81,27 @@ PART
         startEventGUIName = Close cargo bay doors
         endEventGUIName = Open cargo bay doors
         actionGUIName = Toggle cargo bay doors
-		
+
         // availableInEVA = True
         // EVArange = 10
 
         // startRetractEffect = doorMotor
         // startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 1
 		lookupRadius = 3
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 		nodeInnerForeID = top-int
 		nodeInnerAftID = bottom-int
 	}
-	
+
 	MODULE
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Cargo/S2W-6m.cfg
@@ -49,7 +49,7 @@ PART
     breakingForce = 940
     breakingTorque = 940
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo cargo contain fuel fueltank hold protect propellant shield structur therm thermo
+    tags = ?lf ?lfo cargo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Crew/2m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Crew/2m.cfg
@@ -9,7 +9,7 @@ PART
 
     MODEL
     {
-        model = B9_Aerospace/Parts/Cockpit_S2_Body_Crew/2meva 
+        model = B9_Aerospace/Parts/Cockpit_S2_Body_Crew/2meva
     }
     scale = 1.0
     rescaleFactor = 1
@@ -44,6 +44,7 @@ PART
     maxTemp = 2500 // 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = ?iva cabin contain kerbal passenger protect safe shield therm thermo
 
     stagingIcon = COMMAND_POD
     vesselType = Ship
@@ -122,7 +123,7 @@ PART
         evaOnlyStorage = True
         storageRange = 2.0
     }
-	
+
 	MODULE
 	{
 		name = FlagDecal

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Crew/6m.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Crew/6m.cfg
@@ -44,6 +44,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = ?iva cabin contain kerbal passenger protect safe shield therm thermo
 
     stagingIcon = COMMAND_POD
     vesselType = Ship

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Tail/Tail.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Tail/Tail.cfg
@@ -42,7 +42,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-	tags = contain fuel fueltank hold protect shield structur tail therm thermo
+	tags = ?lf ?lfo contain fuel fueltank hold protect propellant shield structur tail therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Tail/Tail.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Tail/Tail.cfg
@@ -42,7 +42,7 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-	tags = ?lf ?lfo contain fuel fueltank hold protect propellant shield structur tail therm thermo
+	tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur tail therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Tail/Tail.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_Body_Tail/Tail.cfg
@@ -42,50 +42,51 @@ PART
     maxTemp = 2500 // = 3000
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
-	
+	tags = contain fuel fueltank hold protect shield structur tail therm thermo
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 2740.0
-		
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-		
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = MonoPropellant
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-		
+
 		SUBTYPE
 		{
 			name = Straight
 			transform = Tail_S
 		}
-		
+
 		SUBTYPE
 		{
 			name = Raised

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM1-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM1-Universal.cfg
@@ -50,7 +50,7 @@ PART
     breakingForce = 1770
     breakingTorque = 1770
 	bulkheadProfiles = size2
-    tags = ?lf ?lfo contain fuel fueltank hold liquid mount protect propellant shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant mount protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM1-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM1-Universal.cfg
@@ -50,7 +50,7 @@ PART
     breakingForce = 1770
     breakingTorque = 1770
 	bulkheadProfiles = size2
-    tags = attach affix contain fuel fueltank hold mount protect shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mount protect propellant shield structur therm thermo
 
 	MODULE
 	{
@@ -60,20 +60,20 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 9940.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM1-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM1-Universal.cfg
@@ -50,6 +50,7 @@ PART
     breakingForce = 1770
     breakingTorque = 1770
 	bulkheadProfiles = size2
+    tags = attach affix contain fuel fueltank hold mount protect shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM2-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM2-Universal.cfg
@@ -48,7 +48,7 @@ PART
     breakingForce = 1410
     breakingTorque = 1410
 	bulkheadProfiles = size2
-    tags = attach affix contain fuel fueltank hold mount protect shield structur therm thermo
+    tags = ?lf ?lfo attach affix contain fuel fueltank hold liquid mount protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM2-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM2-Universal.cfg
@@ -48,7 +48,7 @@ PART
     breakingForce = 1410
     breakingTorque = 1410
 	bulkheadProfiles = size2
-    tags = ?lf ?lfo attach affix contain fuel fueltank hold liquid mount protect propellant shield structur therm thermo
+    tags = ?lf ?lfo attach affix contain fuel fueltank hold liquid mono monopropellant  mount protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM2-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-EM2-Universal.cfg
@@ -48,6 +48,7 @@ PART
     breakingForce = 1410
     breakingTorque = 1410
 	bulkheadProfiles = size2
+    tags = attach affix contain fuel fueltank hold mount protect shield structur therm thermo
 
 	MODULE
 	{
@@ -57,20 +58,20 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 16780.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-Universal.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 5640
     breakingTorque = 5640
 	bulkheadProfiles = size2, size3
+    tags = attach affix contain fuel fueltank hold mount protect shield structur therm thermo
 
 	MODULE
 	{
@@ -54,20 +55,20 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 6500.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-Universal.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 5640
     breakingTorque = 5640
 	bulkheadProfiles = size2, size3
-    tags = ?lf ?lfo contain fuel fueltank hold liquid mount protect propellant shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant mount protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Back-Universal.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 5640
     breakingTorque = 5640
 	bulkheadProfiles = size2, size3
-    tags = attach affix contain fuel fueltank hold mount protect shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mount protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Intake.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Intake.cfg
@@ -47,7 +47,7 @@ PART
     breakingForce = 1929
     breakingTorque = 1929
 	bulkheadProfiles = size2
-    tags = attach affix breathe fuel fueltank hold intake protect shield structur therm thermo
+    tags = attach affix breathe hold intake protect shield structur therm thermo
 
     RESOURCE
     {

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Intake.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Intake.cfg
@@ -47,6 +47,7 @@ PART
     breakingForce = 1929
     breakingTorque = 1929
 	bulkheadProfiles = size2
+    tags = attach affix breathe fuel fueltank hold intake protect shield structur therm thermo
 
     RESOURCE
     {
@@ -72,32 +73,32 @@ PART
 			key = 8 0.01 0 0
 		}
     }
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 4960.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-		
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-		
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleLiftingSurface

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Universal.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 2894
     breakingTorque = 2894
 	bulkheadProfiles = size2
-    tags = adapter attach affix contain fuel fueltank protect shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mount protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Universal.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 2894
     breakingTorque = 2894
 	bulkheadProfiles = size2
-    tags = ?lf ?lfo contain fuel fueltank hold liquid mount protect propellant shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant mount protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body-Front-Universal.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 2894
     breakingTorque = 2894
 	bulkheadProfiles = size2
+    tags = adapter attach affix contain fuel fueltank protect shield structur therm thermo
 
 	MODULE
 	{
@@ -54,20 +55,20 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 7080.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body.cfg
@@ -46,7 +46,7 @@ PART
     breakingForce = 3172
     breakingTorque = 3172
 	bulkheadProfiles = size2, srf
-    tags = contain fuel fueltank hold protect shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body.cfg
@@ -46,7 +46,7 @@ PART
     breakingForce = 3172
     breakingTorque = 3172
 	bulkheadProfiles = size2, srf
-    tags = ?lf ?lfo contain fuel fueltank hold liquid protect propellant shield structur therm thermo
+    tags = ?lf ?lfo contain fuel fueltank hold liquid mono monopropellant protect propellant shield structur therm thermo
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2_W_Body/Body.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 3172
     breakingTorque = 3172
 	bulkheadProfiles = size2, srf
+    tags = contain fuel fueltank hold protect shield structur therm thermo
 
 	MODULE
 	{
@@ -55,20 +56,20 @@ PART
 		affectDragCubes = false
 		affectFARVoxels = false
 		baseVolume = 7780.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 			transform = LF
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace/Parts/Cockpit_S3/Cockpit_S3.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S3/Cockpit_S3.cfg
@@ -39,6 +39,7 @@ PART
     breakingTorque = 400
     maxTemp = 2700// = 3400
 	bulkheadProfiles = size2
+    tags= ?eva capsule command control kerbal pilot react sas supersonic transport view
 
     stagingIcon = COMMAND_POD
     vesselType = Ship

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Block_R12.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Block_R12.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 15
     maxTemp = 2000// = 3600
 	bulkheadProfiles = srf
+    tags = control maneuver manoeuvre rcs rotate steer thruster translate
 
     MODULE
     {
@@ -60,7 +61,7 @@ PART
 		moduleID = meshSwitch
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = Unshielded
@@ -68,7 +69,7 @@ PART
 			maxTemp = 2000
 			skinMaxTemp = 2000
 		}
-		
+
 		SUBTYPE
 		{
 			name = Shielded

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Block_R5.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Block_R5.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 15
     maxTemp = 2000// = 3600
 	bulkheadProfiles = srf
+    tags = control maneuver manoeuvre rcs rotate steer thruster translate
 
     MODULE
     {
@@ -60,7 +61,7 @@ PART
 		moduleID = meshSwitch
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = Unshielded
@@ -68,7 +69,7 @@ PART
 			maxTemp = 2000
 			skinMaxTemp = 2000
 		}
-		
+
 		SUBTYPE
 		{
 			name = Shielded

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Block_R6.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Block_R6.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 15
     maxTemp = 2000 // = 3600
 	bulkheadProfiles = srf
+    tags = control maneuver manoeuvre rcs rotate steer thruster translate
 
     MODULE
     {
@@ -60,7 +61,7 @@ PART
 		moduleID = meshSwitch
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = Unshielded
@@ -68,7 +69,7 @@ PART
 			maxTemp = 2000
 			skinMaxTemp = 2000
 		}
-		
+
 		SUBTYPE
 		{
 			name = Shielded

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Port_R1.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Port_R1.cfg
@@ -42,6 +42,7 @@ PART
     maxTemp = 2000 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = srf
+    tags = control maneuver manoeuvre rcs rotate steer thruster translate
 
     MODULE
     {
@@ -63,7 +64,7 @@ PART
 		moduleID = meshSwitch
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = Unshielded
@@ -71,7 +72,7 @@ PART
 			maxTemp = 2000
 			skinMaxTemp = 2000
 		}
-		
+
 		SUBTYPE
 		{
 			name = Shielded

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Port_R1A.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Blocks/Port_R1A.cfg
@@ -42,6 +42,7 @@ PART
     maxTemp = 2000 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = srf
+    tags = control maneuver manoeuvre oxygen rcs rotate steer thruster translate
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Shielded/control_rcs_shielded_s1.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Shielded/control_rcs_shielded_s1.cfg
@@ -42,6 +42,7 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = srf
+    tags = control maneuver manoeuvre rcs rotate shield steer thruster translate
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Shielded/control_rcs_shielded_s5.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Shielded/control_rcs_shielded_s5.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 15
     maxTemp = 2300// = 3600
 	bulkheadProfiles = srf
+    tags = control maneuver manoeuvre rcs rotate shield steer thruster translate
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Tank_MT/MT1.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Tank_MT/MT1.cfg
@@ -38,6 +38,7 @@ PART
     crashTolerance = 12
     maxTemp = 2000// = 2900
 	bulkheadProfiles = srf
+    tags = fuel fueltank mono monopropellant rcs
 
     RESOURCE
     {

--- a/GameData/B9_Aerospace/Parts/Control_RCS_Tank_MT/MT4.cfg
+++ b/GameData/B9_Aerospace/Parts/Control_RCS_Tank_MT/MT4.cfg
@@ -38,6 +38,7 @@ PART
     crashTolerance = 12
     maxTemp = 2000 // =2900
 	bulkheadProfiles = srf
+    tags = fuel fueltank mono monopropellant rcs
 
     RESOURCE
     {

--- a/GameData/B9_Aerospace/Parts/Engine_Jet_Pod_Medium/Engine_Jet_Pod_Medium.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_Jet_Pod_Medium/Engine_Jet_Pod_Medium.cfg
@@ -54,6 +54,7 @@ PART
     maxTemp = 2000 // = 3600
 	emissiveConstant = 0.8
 	bulkheadProfiles = srf
+    tags = aircraft cargo efficient engine jet launch main propuls subsonic
 
     EFFECTS
     {
@@ -235,7 +236,7 @@ PART
 			key = 1 1 0.9127604 0
 		}
     }
-    
+
     MODULE
     {
         name = ModuleB9AnimateThrottle
@@ -306,18 +307,18 @@ PART
         startRetractEffect = doorMotor
         startDeployEffect = doorMotor
     }
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Pylon Setup
-		
+
 		SUBTYPE
 		{
 			name = None
 		}
-		
+
 		SUBTYPE
 		{
 			name = Straight
@@ -326,7 +327,7 @@ PART
 			addedCost = 80
 			attachNode = 0.0, 0.0, -1.563, 0.0, 0.0, 1.0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Raked
@@ -489,7 +490,7 @@ PART
 			prestige = Exceptional
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSurfaceFX

--- a/GameData/B9_Aerospace/Parts/Engine_Jet_Pod_Small/Engine_Jet_Pod_Small.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_Jet_Pod_Small/Engine_Jet_Pod_Small.cfg
@@ -54,7 +54,8 @@ PART
     maxTemp = 2000 // = 3600
 	emissiveConstant = 0.8
 	bulkheadProfiles = srf
-	
+    tags = aircraft cargo efficient engine jet launch main propuls subsonic
+
     EFFECTS
     {
         power
@@ -169,7 +170,7 @@ PART
             }
         }
     }
-	
+
     MODULE
     {
         name = ModuleEnginesFX
@@ -185,7 +186,7 @@ PART
         engineDecelerationSpeed = 0.55
         useVelocityCurve = False
 		EngineType = Turbine
-		
+
 		PROPELLANT
         {
             name = LiquidFuel
@@ -281,18 +282,18 @@ PART
         //rotorDiscFadeInStart = 0.6
         //rotorDiscSpeed = -30
     }
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Pylon Setup
-		
+
 		SUBTYPE
 		{
 			name = None
 		}
-		
+
 		SUBTYPE
 		{
 			name = Straight
@@ -301,7 +302,7 @@ PART
 			addedCost = 40
 			attachNode = 0.0, 0.0, 1.0, 0.0, 0.0, -1.0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Raked
@@ -464,7 +465,7 @@ PART
 			prestige = Exceptional
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSurfaceFX

--- a/GameData/B9_Aerospace/Parts/Engine_Jet_Turbofan_F119/Engine_Jet_Turbofan_F119.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_Jet_Turbofan_F119/Engine_Jet_Turbofan_F119.cfg
@@ -40,7 +40,8 @@ PART
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8
 	bulkheadProfiles = size1
-	
+    tags = aircraft burner engine hybrid jet maneuver manoeuvre supersonic turb
+
     EFFECTS
     {
         power_wet
@@ -100,7 +101,7 @@ PART
                 loop = true
             }
         }
-		
+
         running_wet
         {
             MODEL_MULTI_PARTICLE_PERSIST
@@ -195,8 +196,8 @@ PART
                 {
                     power = 0 0.2
                     power = 1 3.2
-                    // externaltemp = -10 1
-                    // externaltemp = 1 0
+                    externaltemp = -10 1
+                    externaltemp = 1 0
                     mach = 0 1
                     mach = 10 10
                 }
@@ -282,7 +283,7 @@ PART
             }
         }
     }
-	
+
 	MODULE
 	{
 		name = MultiModeEngine
@@ -291,7 +292,7 @@ PART
 		carryOverThrottle = True
 		autoSwitchAvailable = False
 	}
-	
+
 	MODULE
     {
         name = ModuleEnginesFX
@@ -347,7 +348,7 @@ PART
 			key = 1 1 0.969697 0.969697
 		}
     }
-	
+
 	MODULE
     {
         name = ModuleEnginesFX
@@ -410,10 +411,10 @@ PART
         animationName = jet_engine_f119_throttle
         responseSpeed = 0.02
         layer = 1
-		
+
 		idleState = 1
 		shutdownState = 0
-		
+
 		throttleCurvePrimary
 		{
 			key = 0 1 -1 -1
@@ -424,7 +425,7 @@ PART
 			key = 0 0 0   0
 			key = 4 1 0.8 0.8
 		}
-		
+
 		throttleCurveSecondary
 		{
 			key = 0 0   0.7 0.7
@@ -444,7 +445,7 @@ PART
 		// If it gets fixed then it will be changed back
         name = ModuleB9AnimateThrottle
         animationName = jet_engine_f119_heat
-		responseSpeed = 0.005
+		responseSpeed = 0.0005
 		layer = 2
 		// dependOnEngineState = True
 		engineID = Wet
@@ -467,7 +468,7 @@ PART
         gimbalRange = 0
         gimbalRangeXP = 20
         useGimbalResponseSpeed = true
-        gimbalResponseSpeed = 6
+        gimbalResponseSpeed = 8
     }
 
     RESOURCE
@@ -683,7 +684,7 @@ PART
 			prestige = Exceptional
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSurfaceFX
@@ -693,7 +694,7 @@ PART
 		falloff = 2
 		thrustTransformName = thrust_transform
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSurfaceFX

--- a/GameData/B9_Aerospace/Parts/Engine_Jet_Turbojet/Engine_Jet_Turbojet.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_Jet_Turbojet/Engine_Jet_Turbojet.cfg
@@ -40,7 +40,8 @@ PART
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8
 	bulkheadProfiles = size1
-	
+    tags = aircraft burner engine hybrid jet maneuver manoeuvre supersonic turb
+
     EFFECTS
     {
         power_wet
@@ -99,7 +100,7 @@ PART
                 loop = true
             }
         }
-		
+
         running_wet
         {
             MODEL_MULTI_PARTICLE_PERSIST
@@ -169,7 +170,7 @@ PART
                 loop = true
             }
         }
-		
+
         running_dry
         {
             MODEL_MULTI_PARTICLE_PERSIST
@@ -193,8 +194,8 @@ PART
                 {
                     power = 0 0.2
                     power = 1 3.2
-                    // externaltemp = -10 1
-                    // externaltemp = 1 0
+                    externaltemp = -10 1
+                    externaltemp = 1 0
                     mach = 0 1
                     mach = 10 10
                 }
@@ -238,7 +239,7 @@ PART
                 loop = true
             }
         }
-		
+
         engage
         {
             AUDIO
@@ -281,7 +282,7 @@ PART
             }
         }
     }
-	
+
 	MODULE
 	{
 		name = MultiModeEngine
@@ -408,7 +409,7 @@ PART
 	{
 		name = FXModuleAnimateThrottle
 		animationName = jet_turbofan_heat
-		responseSpeed = 0.005
+		responseSpeed = 0.0005
 		layer = 1
 		dependOnEngineState = True
 		engineName = Wet
@@ -619,7 +620,7 @@ PART
 			prestige = Exceptional
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSurfaceFX
@@ -629,7 +630,7 @@ PART
 		falloff = 2
 		thrustTransformName = thrust_transform
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSurfaceFX

--- a/GameData/B9_Aerospace/Parts/Engine_L2_Atlas/Engine_L2_Atlas.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_L2_Atlas/Engine_L2_Atlas.cfg
@@ -36,6 +36,7 @@ PART
     maxTemp = 2000 // = 3600
 	emissiveConstant = 0.8
 	bulkheadProfiles = size2
+    tags = efficient engine lander propuls sustain thruster vacuum
 
     EFFECTS
     {

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_Body/M.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_Body/M.cfg
@@ -44,6 +44,7 @@ PART
 	emissiveConstant = 0.95
     fuelCrossFeed = True
 	bulkheadProfiles = size2, srf
+    tags = breathe explo fligh inlet intake inter jet oxygen supersonic
 
 	MODULE
 	{
@@ -51,18 +52,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 2060.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_Body/M.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_Body/M.cfg
@@ -26,7 +26,7 @@ PART
     subcategory = 0
     title = SABRE M Precooler
     manufacturer = Tetragon Projects
-    description = As the air enters the engine at supersonic/hypersonic speeds, it becomes very hot due to compression effects. The high temperatures are traditionally dealt with in jet engines by using heavy copper or nickel based materials, by reducing the engine's pressure ratio, and by throttling back the engine at the higher airspeeds to avoid melting. However, for an SSTO craft, such heavy materials are unusable, and maximum thrust is necessary for orbital insertion at the earliest time to minimise gravity losses. Instead, using a gaseous helium coolant loop, SABRE dramatically cools the air from 1000C down to -150C in a heat exchanger. Just kidding, this knockoff piece probably isn't doing anything.
+    description = As the air enters the engine at supersonic/hypersonic speeds, it becomes very hot due to compression effects. The high temperatures are traditionally dealt with in jet engines by using heavy copper or nickel based materials, by reducing the engine's pressure ratio, and by throttling back the engine at the higher airspeeds to avoid melting. However, for an SSTO craft, such heavy materials are unusable, and maximum thrust is necessary for orbital insertion at the earliest time to minimize gravity losses. Instead, using a gaseous helium coolant loop, SABRE dramatically cools the air from 1000C down to -150C in a heat exchanger. Just kidding, this knockoff piece probably isn't doing anything.
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_Body/S.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_Body/S.cfg
@@ -26,7 +26,7 @@ PART
     subcategory = 0
     title = SABRE S Precooler
     manufacturer = Tetragon Projects
-    description = As the air enters the engine at supersonic/hypersonic speeds, it becomes very hot due to compression effects. The high temperatures are traditionally dealt with in jet engines by using heavy copper or nickel based materials, by reducing the engine's pressure ratio, and by throttling back the engine at the higher airspeeds to avoid melting. However, for an SSTO craft, such heavy materials are unusable, and maximum thrust is necessary for orbital insertion at the earliest time to minimise gravity losses. Instead, using a gaseous helium coolant loop, SABRE dramatically cools the air from 1000C down to -150C in a heat exchanger. Just kidding, this knockoff piece probably isn't doing anything.
+    description = As the air enters the engine at supersonic/hypersonic speeds, it becomes very hot due to compression effects. The high temperatures are traditionally dealt with in jet engines by using heavy copper or nickel based materials, by reducing the engine's pressure ratio, and by throttling back the engine at the higher airspeeds to avoid melting. However, for an SSTO craft, such heavy materials are unusable, and maximum thrust is necessary for orbital insertion at the earliest time to minimize gravity losses. Instead, using a gaseous helium coolant loop, SABRE dramatically cools the air from 1000C down to -150C in a heat exchanger. Just kidding, this knockoff piece probably isn't doing anything.
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_Body/S.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_Body/S.cfg
@@ -44,6 +44,7 @@ PART
 	emissiveConstant = 0.95
     fuelCrossFeed = True
 	bulkheadProfiles = size1, srf
+    tags = breathe explo fligh inlet intake inter jet oxygen supersonic
 
 	MODULE
 	{
@@ -51,18 +52,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 260.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_Intake/SABRE_Intake_M.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_Intake/SABRE_Intake_M.cfg
@@ -41,6 +41,7 @@ PART
     maxTemp = 2400 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size2
+    tags = (air breathe inlet intake oxygen supersonic
 
     MODULE
     {
@@ -58,7 +59,7 @@ PART
         amount = 1.0 // dummy value
         maxAmount = 1.0
     }
-	
+
 	MODULE
 	{
 		name = ModuleB9AnimateIntake

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_Intake/SABRE_Intake_M.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_Intake/SABRE_Intake_M.cfg
@@ -21,7 +21,7 @@ PART
     subcategory = 0
     title = SABRE M Intake
     manufacturer = Tetragon Projects.
-    description = A shock cone intake for high supersonic range operation of subsonic combusition air-breathing engines. Peak performance when airflow follows the direction of the shock cone. Made from the finest recycled fast-food carton composite, and painted by children. Size medium. Effective Intake Area: 0.064
+    description = A shock cone intake for high supersonic range operation of subsonic combustion air-breathing engines. Peak performance when airflow follows the direction of the shock cone. Made from the finest recycled fast-food carton composite, and painted by children. Size medium. Effective Intake Area: 0.064
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,1,0,0

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_Intake/SABRE_Intake_S.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_Intake/SABRE_Intake_S.cfg
@@ -41,6 +41,7 @@ PART
     maxTemp = 2400 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size1
+    tags = (air breathe inlet intake oxygen supersonic
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_Intake/SABRE_Intake_S.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_Intake/SABRE_Intake_S.cfg
@@ -21,7 +21,7 @@ PART
     subcategory = 0
     title = SABRE S Intake
     manufacturer = Tetragon Projects.
-    description = A shock cone intake for high supersonic range operation of subsonic combusition air-breathing engines. Peak performance when airflow follows the direction of the shock cone. Made from the finest recycled fast-food carton composite, and painted by children. Size medium. Effective Intake Area: 0.016
+    description = A shock cone intake for high supersonic range operation of subsonic combustion air-breathing engines. Peak performance when airflow follows the direction of the shock cone. Made from the finest recycled fast-food carton composite, and painted by children. Size medium. Effective Intake Area: 0.016
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,1,0,0

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_M/Engine_SABRE_M.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_M/Engine_SABRE_M.cfg
@@ -41,7 +41,8 @@ PART
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8
 	bulkheadProfiles = size2, srf
-	
+    tags = active cycle explo fligh hybrid jet oxygen rocket supersonic turb thruster
+
     EFFECTS
     {
         power_open
@@ -213,8 +214,8 @@ PART
                 {
                     power = 0 0.2
                     power = 1 3.2
-                    // externaltemp = -10 1
-                    // externaltemp = 1 0
+                    externaltemp = -10 1
+                    externaltemp = 1 0
                     mach = 0 1
                     mach = 10 10
                 }
@@ -619,7 +620,7 @@ PART
 			prestige = Exceptional
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSurfaceFX

--- a/GameData/B9_Aerospace/Parts/Engine_SABRE_S/Engine_SABRE_S.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_SABRE_S/Engine_SABRE_S.cfg
@@ -41,7 +41,8 @@ PART
 	skinInternalConductionMult = 4.0
 	emissiveConstant = 0.8
 	bulkheadProfiles = size1, srf
-	
+    tags = active cycle explo fligh hybrid jet oxygen rocket supersonic turb thruster
+
     EFFECTS
     {
         power_open
@@ -212,8 +213,8 @@ PART
                 {
                     power = 0 0.2
                     power = 1 3.2
-                    // externaltemp = -10 1
-                    // externaltemp = 1 0
+                    externaltemp = -10 1
+                    externaltemp = 1 0
                     mach = 0 1
                     mach = 10 10
                 }

--- a/GameData/B9_Aerospace/Parts/Engine_T2_SRBS/T2.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_T2_SRBS/T2.cfg
@@ -48,6 +48,7 @@ PART
     maxTemp = 2000 // = 3600
 	emissiveConstant = 0.8
 	bulkheadProfiles = srf
+	tags = abort booster rocket separat solid srb thurster
 
     ActivatesEvenIfDisconnected = true
 

--- a/GameData/B9_Aerospace/Parts/Engine_T2_SRBS/T2A.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_T2_SRBS/T2A.cfg
@@ -48,6 +48,7 @@ PART
     maxTemp = 2000 // = 3600
 	emissiveConstant = 0.8
 	bulkheadProfiles = srf
+	tags = abort booster reverse rocket separat shield solid srb thurster
 
     ActivatesEvenIfDisconnected = true
 

--- a/GameData/B9_Aerospace/Parts/Engine_VA1/Engine_VA1.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_VA1/Engine_VA1.cfg
@@ -41,7 +41,8 @@ PART
 	emissiveConstant = 0.8
 	skinInternalConductionMult = 4.0
 	bulkheadProfiles = size1, srf
-	
+	tags = aircraft ascent dual efficient jet plane supersonic
+
     EFFECTS
     {
         power

--- a/GameData/B9_Aerospace/Parts/Engine_VS1/Engine_VS1.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_VS1/Engine_VS1.cfg
@@ -40,7 +40,8 @@
 	emissiveConstant = 0.8
 	skinInternalConductionMult = 4.0
 	bulkheadProfiles = size1, srf
-	
+    tags = aircraft ascent dual efficient jet plane supersonic
+
 	EFFECTS
     {
         power
@@ -441,7 +442,7 @@
 			prestige = Exceptional
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleSurfaceFX

--- a/GameData/B9_Aerospace/Parts/Engine_Vx1_Nose/Intake.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_Vx1_Nose/Intake.cfg
@@ -42,6 +42,7 @@ PART
     breakingTorque = 1224
     maxTemp = 1800 // 3400
 	bulkheadProfiles = size1
+    tags = (air breathe inlet intake oxygen
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Engine_Vx1_Nose/Nosecone.cfg
+++ b/GameData/B9_Aerospace/Parts/Engine_Vx1_Nose/Nosecone.cfg
@@ -40,6 +40,7 @@ PART
     breakingTorque = 1224
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size1
+    tags = cone drag fairing nose
 
 	MODULE
 	{
@@ -47,24 +48,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 100.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/L1_Ladder.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/L1_Ladder.cfg
@@ -44,6 +44,7 @@ PART
      maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
     fuelCrossFeed = False
+    tags = climb connect couple fasten fall grab ladder passenger rung static utility
 
     EFFECTS
     {

--- a/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/L2_Ladder.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/L2_Ladder.cfg
@@ -44,6 +44,7 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
     fuelCrossFeed = False
+    tags = climb connect couple ladder passenger static utility
 
     EFFECTS
     {

--- a/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/L4_Ladder.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/L4_Ladder.cfg
@@ -44,6 +44,7 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
     fuelCrossFeed = False
+    tags = climb connect couple ladder passenger static utility
 
     EFFECTS
     {

--- a/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/L8_Ladder.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/L8_Ladder.cfg
@@ -44,6 +44,7 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
     fuelCrossFeed = False
+    tags = climb connect couple fasten fall grab ladder passenger rung static utility
 
     EFFECTS
     {

--- a/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/R0_Railing.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/R0_Railing.cfg
@@ -44,4 +44,5 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
     fuelCrossFeed = False
+    tags = connect equipment fall fasten grab protect rung
 }

--- a/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/R1_Railing.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/R1_Railing.cfg
@@ -41,7 +41,8 @@ PART
     crashTolerance = 8
     breakingForce = 100
     breakingTorque = 100
-     maxTemp = 2000 // = 3400
+    maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
     fuelCrossFeed = False
+    tags = connect equipment fall fasten grab protect rung
 }

--- a/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/R2_Railing.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/R2_Railing.cfg
@@ -44,4 +44,5 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
     fuelCrossFeed = False
+    tags = connect equipment fall fasten grab protect rung
 }

--- a/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/R4_Railing.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_Ladders-Railings/R4_Railing.cfg
@@ -44,4 +44,5 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
     fuelCrossFeed = False
+    tags = connect equipment fall fasten grab protect rung
 }

--- a/GameData/B9_Aerospace/Parts/Structure_PA_Adapter/Structure_PA_Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_PA_Adapter/Structure_PA_Adapter.cfg
@@ -43,6 +43,7 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size2, srf
     fuelCrossFeed = True
+    tags = adapter affix construct fabricate frame join mount scaffold
 
 	MODULE
 	{
@@ -50,18 +51,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 980.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Structure_P_Clear-Half/P1_Surface_Half.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_P_Clear-Half/P1_Surface_Half.cfg
@@ -46,4 +46,5 @@ PART
      maxTemp = 2000 // = 3400
 	bulkheadProfiles = size1, srf
     fuelCrossFeed = True
+    tags = affix body construct fabricate frame mount outpost plate plat scaffold strength
 }

--- a/GameData/B9_Aerospace/Parts/Structure_P_Clear-Half/P2_Surface_Half.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_P_Clear-Half/P2_Surface_Half.cfg
@@ -48,4 +48,5 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size2, srf
     fuelCrossFeed = True
+    tags = affix body construct fabricate frame mount outpost plate plat scaffold strength
 }

--- a/GameData/B9_Aerospace/Parts/Structure_P_Clear-Half/P4_Surface_Half.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_P_Clear-Half/P4_Surface_Half.cfg
@@ -46,4 +46,5 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size3, srf
     fuelCrossFeed = True
+    tags = affix body construct fabricate frame mount outpost plate plat scaffold strength
 }

--- a/GameData/B9_Aerospace/Parts/Structure_P_Clear-Half/P8_Surface_Half.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_P_Clear-Half/P8_Surface_Half.cfg
@@ -48,4 +48,5 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size3, srf
     fuelCrossFeed = True
+    tags = affix body construct fabricate frame mount outpost plate plat scaffold strength
 }

--- a/GameData/B9_Aerospace/Parts/Structure_P_Standard-Frame/P1_Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_P_Standard-Frame/P1_Universal.cfg
@@ -48,4 +48,5 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size1, srf
     fuelCrossFeed = True
+    tags = affix body construct fabricate frame mount outpost plate plat scaffold strength
 }

--- a/GameData/B9_Aerospace/Parts/Structure_P_Standard-Frame/P2_Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_P_Standard-Frame/P2_Universal.cfg
@@ -52,19 +52,20 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size2, srf
     fuelCrossFeed = True
+    tags = affix body construct fabricate frame mount outpost plate plat scaffold strength
 
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-	
+
 		SUBTYPE
 		{
 			name = Surface
 			transform = model_surface_p2
 		}
-	
+
 		SUBTYPE
 		{
 			name = Clear

--- a/GameData/B9_Aerospace/Parts/Structure_P_Standard-Frame/P4_Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_P_Standard-Frame/P4_Universal.cfg
@@ -50,25 +50,26 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size3, srf
     fuelCrossFeed = True
+    tags = affix body construct fabricate frame mount outpost plate plat scaffold strength
 
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-	
+
 		SUBTYPE
 		{
 			name = Surface
 			transform = model_surface_p4
 		}
-	
+
 		SUBTYPE
 		{
 			name = Clear
 			transform = model_surface_p4_clear
 		}
-	
+
 		SUBTYPE
 		{
 			name = Frame

--- a/GameData/B9_Aerospace/Parts/Structure_P_Standard-Frame/P8_Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_P_Standard-Frame/P8_Universal.cfg
@@ -60,32 +60,33 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size3, srf
     fuelCrossFeed = True
+    tags = affix body construct fabricate frame mount outpost plate plat scaffold strength
 
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-	
+
 		SUBTYPE
 		{
 			name = Surface
 			transform = model_surface_p8
 		}
-	
+
 		SUBTYPE
 		{
 			name = Clear
 			transform = model_surface_p8_clear
 		}
-	
+
 		SUBTYPE
 		{
 			name = Frame_1
 			title = Frame 1
 			transform = model_surface_p8_hollow
 		}
-	
+
 		SUBTYPE
 		{
 			name = Frame_2

--- a/GameData/B9_Aerospace/Parts/Structure_SNM_Strut/Structure_SNM_Strut.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_SNM_Strut/Structure_SNM_Strut.cfg
@@ -45,4 +45,5 @@ PART
     linearStrength = 2250
     angularStrength = 2250
     maxLength = 15
+    tags = affix base connect girder join mount pair rigid scaffold secure strength strong stru strut truss wobble
 }

--- a/GameData/B9_Aerospace/Parts/Structure_SN_Strut/Structure_SN_Strut.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_SN_Strut/Structure_SN_Strut.cfg
@@ -45,4 +45,6 @@ PART
     linearStrength = 2250
     angularStrength = 2250
     maxLength = 15
+
+    tags = affix base connect girder join mount pair rigid scaffold secure strength strong stru strut truss wobble
 }

--- a/GameData/B9_Aerospace/Parts/Structure_StackSeparator_MSR/Structure_StackSeparator_MSR.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_StackSeparator_MSR/Structure_StackSeparator_MSR.cfg
@@ -49,6 +49,7 @@ PART
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = size0
     fuelCrossFeed = False
+    tags = break connect decouple explo join mount separat split stack
 
     stageOffset = 1
     childStageOffset = 1

--- a/GameData/B9_Aerospace/Parts/Structure_StackSeparator_MSR/Structure_StackSeparator_MSR.cfg
+++ b/GameData/B9_Aerospace/Parts/Structure_StackSeparator_MSR/Structure_StackSeparator_MSR.cfg
@@ -32,7 +32,7 @@ PART
     subcategory = 0
     title = MSR Multipurpose Stacked Booster
     manufacturer = Tetragon Projects
-    description = Stack separator and a set of boosters packed into one part. Not a particularly useful thing, mostly suitable for exotic applications like multi-stage probes. Beyound that, it's packed with extendable fins, which have no use and just make it more likely for the thing to hit something. Unless that's what you're looking for - then it's a nice replacement for good old sepratron-powered missiles.
+    description = Stack separator and a set of boosters packed into one part. Not a particularly useful thing, mostly suitable for exotic applications like multi-stage probes. Beyond that, it's packed with extendable fins, which have no use and just make it more likely for the thing to hit something. Unless that's what you're looking for - then it's a nice replacement for good old sepratron-powered missiles.
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,1,1,0

--- a/GameData/B9_Aerospace/Parts/Utility_DockingPort_CDP/Utility_DockingPort_CDP.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_DockingPort_CDP/Utility_DockingPort_CDP.cfg
@@ -30,7 +30,7 @@ PART
     breakingTorque = 200
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = mk2, size2, srf
-	
+	tags = aero connect couple dock grab join port protect shield
 
     EFFECTS
     {

--- a/GameData/B9_Aerospace/Parts/Utility_InfoDrive/Utility_InfoDrive.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_InfoDrive/Utility_InfoDrive.cfg
@@ -38,21 +38,22 @@ PART
     crashTolerance = 9
     maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
+    tags = deploy direct science
 
     MODULE
     {
         name = FSinfoPopup
         textHeading = Craft Information
-        textBody1 = 1 - 
-        textBody2 = 2 - 
-        textBody3 = 3 - 
-        textBody4 = 4 - 
-        textBody5 = 5 - 
-        textBody6 = 6 - 
-        textBody7 = 7 - 
-        textBody8 = 8 - 
-        textBody9 = 9 - 
-        textBody10 = 0 - 
+        textBody1 = 1 -
+        textBody2 = 2 -
+        textBody3 = 3 -
+        textBody4 = 4 -
+        textBody5 = 5 -
+        textBody6 = 6 -
+        textBody7 = 7 -
+        textBody8 = 8 -
+        textBody9 = 9 -
+        textBody10 = 0 -
         textBody11 = Press [ o ] to toggle this window.
         showAtFlightStart = true
         hideAfterCountdown = true

--- a/GameData/B9_Aerospace/Parts/Utility_Leg_H50/H50.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Leg_H50/H50.cfg
@@ -37,6 +37,7 @@ PART
     crashTolerance = 120
     maxTemp = 2000// = 2900
 	bulkheadProfiles = srf
+    tags = berth deploy descen descend extend lander land landing leg safe solid support surviv utility
 
     CoMOffset = 0, 0, 0
 

--- a/GameData/B9_Aerospace/Parts/Utility_Leg_H50/H50P.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Leg_H50/H50P.cfg
@@ -37,6 +37,7 @@ PART
     crashTolerance = 120
     maxTemp = 2000// = 2900
 	bulkheadProfiles = srf
+    tags = berth deploy descen descend extend lander land landing leg safe solid support surviv utility
 
     CoMOffset = 0, 0, 0
 

--- a/GameData/B9_Aerospace/Parts/Utility_Light_A/A1_Closed_U.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Light_A/A1_Closed_U.cfg
@@ -41,6 +41,7 @@ PART
     crashTolerance = 8
     maxTemp = 2000 // = 3200
 	bulkheadProfiles = srf
+    tags = (lamp (light bulb dark flash power
 
     MODULE
     {
@@ -54,14 +55,14 @@ PART
         animationName = light_array_toggle4
         useResources = true
     }
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		affectDragCubes = false
 		affectFARVoxels = false
-		
+
 		SUBTYPE
 		{
 			name = Unshielded
@@ -69,7 +70,7 @@ PART
 			maxTemp = 2000
 			skinMaxTemp = 2000
 		}
-		
+
 		SUBTYPE
 		{
 			name = Shielded

--- a/GameData/B9_Aerospace/Parts/Utility_Light_A/A1_White.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Light_A/A1_White.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 8
     maxTemp = 2000 // = 3200
 	bulkheadProfiles = srf
+    tags = (lamp (light bulb dark flash power
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Utility_Light_A/A4_White.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Light_A/A4_White.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 8
     maxTemp = 2000 // = 3200
 	bulkheadProfiles = srf
+    tags = (lamp (light array bulb dark flash power
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Utility_Light_A/A8_White.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Light_A/A8_White.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 8
     maxTemp = 2000 // = 3200
 	bulkheadProfiles = srf
+    tags = (lamp (light array bulb dark flash power
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Utility_Light_N/N1_Omni_Small.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Light_N/N1_Omni_Small.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 8
     maxTemp = 2000 // = 3200
 	bulkheadProfiles = srf
+    tags = (lamp (light bulb dark flash
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Utility_Light_N/N2_Omni_Large.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Light_N/N2_Omni_Large.cfg
@@ -39,6 +39,7 @@ PART
     crashTolerance = 8
     maxTemp = 2000 // = 3200
 	bulkheadProfiles = srf
+    tags = (lamp (light bulb dark flash
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Nosecone.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Nosecone.cfg
@@ -24,7 +24,7 @@ PART
     subcategory = 0
     title = MK1 Nosecone
     manufacturer = Tetragon Projects
-    description = Simple nosecone which, depending on aerodynamics model you choose to believe (its better be FAR) can greatly help you to produce something flyable.
+    description = Simple nosecone which, depending on aerodynamics model you choose to believe (it better be FAR) can greatly help you to produce something flyable.
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,1,1,0
@@ -40,6 +40,7 @@ PART
     breakingTorque = 1224
     maxTemp = 2300 // = 3400
 	bulkheadProfiles = size1
+    tags = aero cone fairing fligh nose
 
 	MODULE
 	{
@@ -47,24 +48,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 180.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LiquidFuel
 			tankType = LiquidFuel
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Nosecone_Science.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Nosecone_Science.cfg
@@ -40,6 +40,7 @@ PART
     breakingTorque = 1224
     maxTemp = 2300 // = 3400
 	bulkheadProfiles = size1
+    tags = atmospher bay experiment material research science
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Nosecone_Sensor.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Nosecone_Sensor.cfg
@@ -41,6 +41,7 @@ PART
     breakingTorque = 1224
      maxTemp = 2300 // = 3400
 	bulkheadProfiles = size1
+    tags = atmospher bay experiment material pressure research science sensor temperature
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Radial_Science.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Radial_Science.cfg
@@ -45,6 +45,7 @@ PART
     breakingTorque = 75
      maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
+    tags = atmospher bay experiment material pressure research science sensor
 
     MODULE
     {

--- a/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Radial_Sensor.cfg
+++ b/GameData/B9_Aerospace/Parts/Utility_Nosecone_Science/Radial_Sensor.cfg
@@ -45,6 +45,7 @@ PART
     breakingTorque = 75
      maxTemp = 2000 // = 3400
 	bulkheadProfiles = srf
+    tags = atmospher bay experiment material pressure research science sensor temperature
 
     MODULE
     {

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/body_hx_hangar_shield_a.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/body_hx_hangar_shield_a.cfg
@@ -49,6 +49,7 @@ PART
     maxTemp = 2000
 	bulkheadProfiles = srf
     fuelCrossFeed = True
+    tags = body connect decouple join plate shield split statio
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/body_hx_hangar_shield_b.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/body_hx_hangar_shield_b.cfg
@@ -49,6 +49,7 @@ PART
     maxTemp = 2000
 	bulkheadProfiles = srf
     fuelCrossFeed = True
+    tags = body connect decouple join plate shield split statio
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hpd1.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hpd1.cfg
@@ -42,7 +42,8 @@ PART
     breakingForce = 1388800
     breakingTorque = 1388800
     bulkheadProfiles = hx
-	
+    tags = (more efficient engine hybrid liquid launch nuclear propuls reactor rocket
+
     EFFECTS
     {
         power_closed
@@ -350,11 +351,11 @@ PART
         animationName = hx_hpd2_heat
         responseSpeed = 0.005
         layer = 1
-		
+
 		idleState = 0
 		idleThreshold = -1
 		shutdownState = 0
-		
+
 		throttleCurvePrimary
 		{
 			key = 0 0 0 1
@@ -364,7 +365,7 @@ PART
 		{
 			key = 0 0
 		}
-		
+
 		throttleCurveSecondary
 		{
 			key = 0 0   0   0.5
@@ -375,7 +376,7 @@ PART
 			key = 0 0
 		}
     }
-	
+
 	MODULE
 	{
 		name = ModuleTestSubject

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_2m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_2m.cfg
@@ -47,7 +47,7 @@ PART
     breakingTorque = 1600
     CoMOffset = 0, 0, -0.42
 	bulkheadProfiles = hx,srf
-    tags = affix adapter body build connect construct fabricate frame structur
+    tags = ?lf ?lfo affix adapter body build connect construct fabricate fuel frame liquid mono monopropellant structur
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_2m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_2m.cfg
@@ -29,7 +29,7 @@ PART
     subcategory = 0
     title = HX-S 2m Auxillary Module
     manufacturer = Tetragon Projects
-    description = This module is designed to be fitted onto the 2m wide corner surfaces of HX modules, allowing wider rande of designs to be produced. The module can house liquid fuel and monopropellant, serve as a lightweight support structure or accomodate connections with any 1.25m part via a proper adapter subtype. Compatible RCS thruster blocks are also available as separate parts. 
+    description = This module is designed to be fitted onto the 2m wide corner surfaces of HX modules, allowing wider range of designs to be produced. The module can house liquid fuel and monopropellant, serve as a lightweight support structure or accommodate connections with any 1.25m part via a proper adapter subtype. Compatible RCS thruster blocks are also available as separate parts.
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
@@ -47,6 +47,7 @@ PART
     breakingTorque = 1600
     CoMOffset = 0, 0, -0.42
 	bulkheadProfiles = hx,srf
+    tags = affix adapter body build connect construct fabricate frame structur
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_2m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_2m.cfg
@@ -47,7 +47,7 @@ PART
     breakingTorque = 1600
     CoMOffset = 0, 0, -0.42
 	bulkheadProfiles = hx,srf
-    tags = ?lf ?lfo affix adapter body build connect construct fabricate fuel frame liquid mono monopropellant structur
+    tags = ?lf ?lfo affix adapter body build connect construct fabricate fuel frame liquid mono monopropellant propellant structur
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_8m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_8m.cfg
@@ -47,7 +47,7 @@ PART
     breakingTorque = 100
     CoMOffset = 0, 0, -0.42
 	bulkheadProfiles = hx,srf
-    tags = affix adapter body build connect construct fabricate frame structur
+    tags = ?lf ?lfo affix adapter body build connect construct fabricate fuel frame liquid mono monopropellant structur
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_8m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_8m.cfg
@@ -47,7 +47,7 @@ PART
     breakingTorque = 100
     CoMOffset = 0, 0, -0.42
 	bulkheadProfiles = hx,srf
-    tags = ?lf ?lfo affix adapter body build connect construct fabricate fuel frame liquid mono monopropellant structur
+    tags = ?lf ?lfo affix adapter body build connect construct fabricate fuel frame liquid mono monopropellant propellant structur
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_8m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_8m.cfg
@@ -29,7 +29,7 @@ PART
     subcategory = 0
     title = HX-S 8m Auxillary Module
     manufacturer = Tetragon Projects
-    description = This module is designed to be fitted onto the 2m wide corner surfaces of HX modules, allowing wider rande of designs to be produced. The module can house liquid fuel and monopropellant as well as serve as the lightweight support structure. Compatible RCS thruster blocks are also available as separate parts. 
+    description = This module is designed to be fitted onto the 2m wide corner surfaces of HX modules, allowing wider rande of designs to be produced. The module can house liquid fuel and monopropellant as well as serve as the lightweight support structure. Compatible RCS thruster blocks are also available as separate parts.
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,1,0
@@ -47,8 +47,8 @@ PART
     breakingTorque = 100
     CoMOffset = 0, 0, -0.42
 	bulkheadProfiles = hx,srf
-	
-	
+    tags = affix adapter body build connect construct fabricate frame structur
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_rcs_front.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_rcs_front.cfg
@@ -46,7 +46,8 @@ PART
     breakingTorque = 1600
     CoMOffset = 0, 0, -0.42
 	bulkheadProfiles = hx,srf
-	
+    tags = control fly nose rcs react torque
+
     MODULE
     {
         name = ModuleRCS

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_rcs_lat.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_side_rcs_lat.cfg
@@ -47,7 +47,8 @@ PART
     breakingTorque = 1600
     CoMOffset = 0, 0, -0.42
 	bulkheadProfiles = hx,srf
-    
+    tags = control fly nose rcs react torque
+
 	MODULE
     {
         name = ModuleRCS

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size0_endpiece.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size0_endpiece.cfg
@@ -44,6 +44,7 @@ PART
     breakingForce = 278760
     breakingTorque = 278760
 	bulkheadProfiles = hx
+    tags = build connect construct fabricate hold mount multi outpost plate stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size0_structure.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size0_structure.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 39200
     breakingTorque = 39200
 	bulkheadProfiles = hx,srf
+    tags = affix build construct hub outpost scaffold statio stru structur
 
 	MODULE
 	{
@@ -53,24 +54,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 26640.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = B9_HX_MonoPropellant
 		}
-	
+
 		SUBTYPE
 		{
 			name = Battery

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_375m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_375m.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 5555200
     breakingTorque = 5555200
 	bulkheadProfiles = hx
+    tags = adapter affix base body construct extend fabricate join outpost statio stru structur
 
     MODULE
     {
@@ -61,21 +62,21 @@ PART
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-	
+
 		SUBTYPE
 		{
 			name = size_1
 			title = Size 1 port
 			transform = model_hx_size1_adapter_375m_a
 		}
-	
+
 		SUBTYPE
 		{
 			name = size_2
 			title = Size 2 port assembly (1/2)
 			transform = model_hx_size1_adapter_375m_b
 		}
-	
+
 		SUBTYPE
 		{
 			name = size_3

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_375m_b.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_375m_b.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 274330
     breakingTorque = 274330
 	bulkheadProfiles = hx
+    tags = adapter affix base body construct extend fabricate join outpost statio stru structur
 
 	MODULE
 	{
@@ -52,18 +53,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 22500.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_375m_c.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_375m_c.cfg
@@ -45,7 +45,8 @@ PART
     breakingForce = 2458980
     breakingTorque = 2458980
 	bulkheadProfiles = hx
-	
+    tags = adapter affix base body construct extend fabricate join outpost statio stru structur
+
 	// STR1 - 45.86m3
 	// STR2 - 25.09m3
 
@@ -55,7 +56,7 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 4340.0
-	
+
 		SUBTYPE
 		{
 			name = a_str
@@ -64,7 +65,7 @@ PART
 			addedCost = 3115.0
 			transform = STR1
 		}
-	
+
 		SUBTYPE
 		{
 			name = a_lfo
@@ -75,14 +76,14 @@ PART
 			volumeAdded = 3600.0
 			transform = STR1
 		}
-	
+
 		SUBTYPE
 		{
 			name = b_str
 			title = Type B (Structural)
 			transform = STR2
 		}
-	
+
 		SUBTYPE
 		{
 			name = b_lfo

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_lll.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_lll.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 347200
     breakingTorque = 347200
 	bulkheadProfiles = hx
+    tags = adapter affix base body construct extend fabricate join outpost statio stru structur
 
 	MODULE
 	{
@@ -52,12 +53,12 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 15240.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_panel.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_panel.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 347200
     breakingTorque = 347200
 	bulkheadProfiles = hx
+    tags = adapter affix base body construct extend fabricate join outpost statio stru structur
 
 	MODULE
 	{
@@ -53,12 +54,12 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 18340.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_side.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_side.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 3472000
     breakingTorque = 3472000
 	bulkheadProfiles = hx,srf
+    tags = adapter affix base body construct extend fabricate join outpost statio stru structur
 
 	MODULE
 	{
@@ -53,12 +54,12 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 64040.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
@@ -71,14 +72,14 @@ PART
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-	
+
 		SUBTYPE
 		{
 			name = type_a
 			title = Type A
 			transform = STR1
 		}
-	
+
 		SUBTYPE
 		{
 			name = type_b

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_size0.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_adapter_size0.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 86800
     breakingTorque = 86800
 	bulkheadProfiles = hx,srf
+    tags = adapter affix base body construct extend fabricate join outpost statio stru structur
 
 	MODULE
 	{
@@ -53,18 +54,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 42860.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_endpiece1.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_endpiece1.cfg
@@ -44,6 +44,7 @@ PART
     breakingForce = 347200
     breakingTorque = 347200
 	bulkheadProfiles = hx
+    tags = build connect construct fabricate hold mount multi outpost plate stru structur support tail
 
 	MODULE
 	{
@@ -51,18 +52,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 39280.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_generator.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_generator.cfg
@@ -29,7 +29,7 @@ PART
     subcategory = 0
     title = HX1-URC Reactor
     manufacturer = Tetragon Projects
-    description = This reactor system is most commonly used in conjunction with the HX-HPD engine. The substantial power output of the reactor is still insufficient to contiuously power that engine in it's primary propulsion mode, necessitating use of the HX-UB capacitors to complete most designs utilizing it. HX series provides heavy structural components for large installations. Due to mass and size of the modules, designs utilizing them are usually assembled in orbit.
+    description = This reactor system is most commonly used in conjunction with the HX-HPD engine. The substantial power output of the reactor is still insufficient to continuously power that engine in it's primary propulsion mode, necessitating use of the HX-UB capacitors to complete most designs utilizing it. HX series provides heavy structural components for large installations. Due to mass and size of the modules, designs utilizing them are usually assembled in orbit.
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,1,1,0,0
@@ -46,6 +46,7 @@ PART
     breakingForce = 86800
     breakingTorque = 86800
 	bulkheadProfiles = hx,srf
+    tags = (stor capacitor charge contain equipment generat outpost power utility watt
 
     MODULE
     {

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_hangar.cfg
@@ -52,7 +52,7 @@ PART
     breakingForce = 868000
     breakingTorque = 868000
 	bulkheadProfiles = hx,srf
-	tags = (more build connect construct fabricate hold mount multi outpost plate stru structur support
+	tags = ?lf ?lfo (more build connect construct fabricate fuel hold liquid mount multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_hangar.cfg
@@ -52,7 +52,7 @@ PART
     breakingForce = 868000
     breakingTorque = 868000
 	bulkheadProfiles = hx,srf
-	tags = ?lf ?lfo (more build connect construct fabricate fuel hold liquid mono monopropellant mount propellant multi outpost plate propellant stru structur support
+	tags = build connect construct fabricate hold mount multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_hangar.cfg
@@ -18,7 +18,7 @@ PART
     node_stack_top     = 0.0,  4.0, 0.0,    0.0,  1.0,  0.0, 6
     node_stack_bottom  = 0.0, -4.0, 0.0,    0.0, -1.0,  0.0, 6
     node_attach        = 0.0,  0.0, 3.4142, 0.0,  0.0, -1.0
-	
+
     node_stack_front   =  0.0,     0.0,  3.11421, 0.0, 0.0,  1.0, 3
     node_stack_back    =  0.0,     0.0, -3.11421, 0.0, 0.0, -1.0, 3
     node_stack_left    =  3.11421, 0.0,  0.0,     1.0, 0.0,  0.0, 3
@@ -52,12 +52,13 @@ PART
     breakingForce = 868000
     breakingTorque = 868000
 	bulkheadProfiles = hx,srf
-	
+	tags = (more build connect construct fabricate hold mount multi outpost plate stru structur support
+
 	DRAG_CUBE
 	{
 		cube = Default, 54.75,0.8655895,1.574243, 54.75,0.8664179,1.574243, 42.67929,0.9989556,0.482353, 42.67929,0.9989556,0.482353, 55.44532,0.8759691,2.149872, 55.44532,0.8759691,2.149872, 0,0,0, 6.968429,8.000001,6.828429
 	}
-	
+
 	// size1_hangar1 @ 89.3728m3
 	// size1_hangar2 @ 76.2012m3
 	// size1_hangar3 @ 63.0296m3
@@ -70,14 +71,14 @@ PART
 		moduleID = meshSwitch
 		switcherDescription = Hangar Setup
 		affectDragCubes = false
-	
+
 		SUBTYPE
 		{
 			name = Enclosed
 			addedMass = 4.63
 			transform = model_hx_size1_hangar1
 		}
-	
+
 		SUBTYPE
 		{
 			name = Semi_a
@@ -86,7 +87,7 @@ PART
 			transform = model_hx_size1_hangar2
 			node = back
 		}
-	
+
 		SUBTYPE
 		{
 			name = Semi_b
@@ -96,7 +97,7 @@ PART
 			node = front
 			node = back
 		}
-	
+
 		SUBTYPE
 		{
 			name = Semi_c
@@ -107,7 +108,7 @@ PART
 			node = left
 			node = right
 		}
-	
+
 		SUBTYPE
 		{
 			name = Open
@@ -118,14 +119,14 @@ PART
 			node = right
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 0
 		lookupRadius = 4
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 	}

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_hangar.cfg
@@ -52,7 +52,7 @@ PART
     breakingForce = 868000
     breakingTorque = 868000
 	bulkheadProfiles = hx,srf
-	tags = ?lf ?lfo (more build connect construct fabricate fuel hold liquid mount multi outpost plate propellant stru structur support
+	tags = ?lf ?lfo (more build connect construct fabricate fuel hold liquid mono monopropellant mount propellant multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_sas.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_sas.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 1388800
     breakingTorque = 1388800
 	bulkheadProfiles = hx
+    tags = advanced command control gyro maneuver manoeuvre rendezvous sas steer
 
     MODULE
     {

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub3.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub3.cfg
@@ -48,4 +48,5 @@ PART
     breakingForce = 120140
     breakingTorque = 120140
 	bulkheadProfiles = hx
+    tags = affix body build central frame girder hub mount scaffold structur support
 }

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub4.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub4.cfg
@@ -48,4 +48,5 @@ PART
     breakingForce = 120140
     breakingTorque = 120140
 	bulkheadProfiles = hx
+    tags = build connect construct fabricate hold mount multi outpost stru structur support
 }

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub6.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub6.cfg
@@ -51,5 +51,5 @@ PART
     breakingForce = 120140
     breakingTorque = 120140
 	bulkheadProfiles = hx
-    tags = build connect construct fabricate hold mount multi outpost plate stru structur support
+    tags = ?lf ?lfo build connect construct fabricate fuel fueltank hold liquid mount multi outpost mono monopropellant plate stru structur support
 }

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub6.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub6.cfg
@@ -51,4 +51,5 @@ PART
     breakingForce = 120140
     breakingTorque = 120140
 	bulkheadProfiles = hx
+    tags = build connect construct fabricate hold mount multi outpost plate stru structur support
 }

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub6.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub6.cfg
@@ -33,6 +33,7 @@ PART
     title = HX1-S-H6 Structural Hub
     manufacturer = Tetragon Projects
     description = Structural hub providing 6-way connections. HX series provides heavy structural components for large installations. Due to mass and size of the modules, designs utilizing them are usually assembled in orbit.
+    tags = build connect construct fabricate hold mount multi outpost plate stru structur support
 
     // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
     attachRules = 1,0,1,1,0

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub_support.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_hub_support.cfg
@@ -48,6 +48,7 @@ PART
     breakingForce = 15431110
     breakingTorque = 15431110
 	bulkheadProfiles = hx
+    tags = affix body build central frame girder hub mount scaffold structur support
 
 	MODULE
 	{
@@ -55,24 +56,24 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 3580.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = B9_HX_MonoPropellant
 		}
-	
+
 		SUBTYPE
 		{
 			name = Battery

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_turn.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_structure_turn.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 347200
     breakingTorque = 347200
 	bulkheadProfiles = hx
+    tags = adapter affix build connect construct fabricate hold mount multi outpost stru structur support
 
 	MODULE
 	{
@@ -52,18 +53,18 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 29500.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal.cfg
@@ -46,7 +46,7 @@ PART
     breakingForce = 86800
     breakingTorque = 86800
 	bulkheadProfiles = hx,srf
-	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mount multi outpost plate propellant rcs stru structur support
+	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mono monopropellant mount multi outpost plate propellant rcs stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal.cfg
@@ -46,7 +46,7 @@ PART
     breakingForce = 86800
     breakingTorque = 86800
 	bulkheadProfiles = hx,srf
-    tags = affix connect construct fabricate hold mount stru structur support
+	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mount multi outpost plate propellant rcs stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 86800
     breakingTorque = 86800
 	bulkheadProfiles = hx,srf
+    tags = affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -53,28 +54,28 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 59000.0
-	
+
 		SUBTYPE
 		{
 			name = str_a
 			title = Structure A
 			transform = STR1
 		}
-	
+
 		SUBTYPE
 		{
 			name = str_b
 			title = Structure B
 			transform = STR2
 		}
-	
+
 		SUBTYPE
 		{
 			name = str_c
 			title = Structure C
 			transform = STR3
 		}
-	
+
 		SUBTYPE
 		{
 			name = tank_lfo
@@ -82,7 +83,7 @@ PART
 			tankType = B9_HX_LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = tank_mono
@@ -90,7 +91,7 @@ PART
 			tankType = B9_HX_MonoPropellant
 			transform = RCS
 		}
-	
+
 		SUBTYPE
 		{
 			name = battery

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal_s.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal_s.cfg
@@ -46,7 +46,7 @@ PART
     breakingForce = 1388800
     breakingTorque = 1388800
 	bulkheadProfiles = hx,srf
-    tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mount multi outpost plate propellant rcs stru structur support
+    tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mono monopropellant mount multi outpost plate propellant rcs stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal_s.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal_s.cfg
@@ -46,6 +46,7 @@ PART
     breakingForce = 1388800
     breakingTorque = 1388800
 	bulkheadProfiles = hx,srf
+    tags = affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -53,27 +54,27 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 14740.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = B9_HX_MonoPropellant
 			transform = RCS
 		}
-	
+
 		SUBTYPE
 		{
 			name = Battery

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal_s.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size1_universal_s.cfg
@@ -46,7 +46,7 @@ PART
     breakingForce = 1388800
     breakingTorque = 1388800
 	bulkheadProfiles = hx,srf
-    tags = affix connect construct fabricate hold mount stru structur support
+    tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mount multi outpost plate propellant rcs stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_adapter_375m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_adapter_375m.cfg
@@ -45,6 +45,8 @@ PART
     breakingForce = 12288000
     breakingTorque = 12288000
 	bulkheadProfiles = hx
+    tags = adapter affix build connect dock hold mount stru structur support
+
 
     MODULE
     {
@@ -61,14 +63,14 @@ PART
 		name = ModuleB9PartSwitch
 		moduleID = meshSwitch
 		switcherDescription = Subtype
-	
+
 		SUBTYPE
 		{
 			name = size_2
 			title = Size 2 port
 			transform = model_hx_size2_adapter_375m_a
 		}
-	
+
 		SUBTYPE
 		{
 			name = size_3

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_adapter_size1_a.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_adapter_size1_a.cfg
@@ -49,6 +49,7 @@ PART
     breakingForce = 192000
     breakingTorque = 192000
 	bulkheadProfiles = hx,srf
+    tags = adapter affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -56,31 +57,31 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 91260.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Double

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_adapter_size1_b.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_adapter_size1_b.cfg
@@ -49,6 +49,7 @@ PART
     breakingForce = 48000
     breakingTorque = 48000
 	bulkheadProfiles = hx,srf
+    tags = affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -56,31 +57,31 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 182520.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Double

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_hangar.cfg
@@ -56,7 +56,7 @@ PART
     breakingForce = 1920000
     breakingTorque = 1920000
 	bulkheadProfiles = hx,srf
-    tags = base build construct fabricate fuel hold hollow mount shield stru structur support
+	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mount multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_hangar.cfg
@@ -22,7 +22,7 @@ PART
     node_stack_bottom1 =  3.41,   -4.0,  0.0,     0.0, -1.0,  0.0, 6
     node_stack_bottom2 = -3.41,   -4.0,  0.0,     0.0, -1.0,  0.0, 6
     node_attach        =  0.0,     0.0,  3.4142,  0.0,  0.0, -1.0
-	
+
     node_stack_front   =  0.0,     0.0,  3.11421, 0.0,  0.0,  1.0, 3
     node_stack_back    =  0.0,     0.0, -3.11421, 0.0,  0.0, -1.0, 3
     node_stack_left    =  6.52843, 0.0,  0.0,     1.0,  0.0,  0.0, 4
@@ -56,12 +56,13 @@ PART
     breakingForce = 1920000
     breakingTorque = 1920000
 	bulkheadProfiles = hx,srf
-	
+    tags = base build construct fabricate fuel hold hollow mount shield stru structur support
+
 	DRAG_CUBE
 	{
 		cube = Default, 54.75,0.8778161,1.521537, 54.75,0.8778161,1.521537, 89.25196,1,0.09647061, 89.25196,1,0.09647061, 108.5491,0.9394761,1.515936, 108.5491,0.9394761,1.515936, 0,0,0, 13.65686,8.000002,6.828429
 	}
-	
+
 	// size2_hangar1 @ 144.0002m3
 	// size2_hangar2 @ 117.657m3
 	// size2_hangar3 @ 103.5149m3
@@ -74,14 +75,14 @@ PART
 		moduleID = meshSwitch
 		switcherDescription = Hangar Setup
 		affectDragCubes = false
-	
+
 		SUBTYPE
 		{
 			name = Enclosed
 			addedMass = 9.44
 			transform = model_hx_size2_hangar1
 		}
-	
+
 		SUBTYPE
 		{
 			name = Semi_A
@@ -91,7 +92,7 @@ PART
 			node = left
 			node = right
 		}
-	
+
 		SUBTYPE
 		{
 			name = Semi_B
@@ -100,7 +101,7 @@ PART
 			transform = model_hx_size2_hangar3
 			node = back
 		}
-	
+
 		SUBTYPE
 		{
 			name = Semi_C
@@ -110,7 +111,7 @@ PART
 			node = front
 			node = back
 		}
-	
+
 		SUBTYPE
 		{
 			name = Open
@@ -121,19 +122,19 @@ PART
 			node = right
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = topNodeSwitch
 		switcherDescription = Top Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = top0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Double
@@ -141,19 +142,19 @@ PART
 			node = top2
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Double
@@ -161,14 +162,14 @@ PART
 			node = bottom2
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 0
 		lookupRadius = 4
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 	}

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_hangar.cfg
@@ -56,7 +56,7 @@ PART
     breakingForce = 1920000
     breakingTorque = 1920000
 	bulkheadProfiles = hx,srf
-	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mount multi outpost plate propellant stru structur support
+	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mono monopropellant mount multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_hangar.cfg
@@ -56,7 +56,7 @@ PART
     breakingForce = 1920000
     breakingTorque = 1920000
 	bulkheadProfiles = hx,srf
-	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mono monopropellant mount multi outpost plate propellant stru structur support
+	tags = build connect construct fabricate hold mount multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_universal.cfg
@@ -51,6 +51,7 @@ PART
     breakingForce = 192000
     breakingTorque = 192000
 	bulkheadProfiles = hx
+    tags = adapter affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -58,27 +59,27 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 123520.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = STR
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 			transform = LFO
 		}
-	
+
 		SUBTYPE
 		{
 			name = MonoPropellant
 			tankType = B9_HX_MonoPropellant
 			transform = RCS
 		}
-	
+
 		SUBTYPE
 		{
 			name = Battery
@@ -86,19 +87,19 @@ PART
 			transform = Capacitor
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = topNodeSwitch
 		switcherDescription = Top Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = top0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Double
@@ -106,19 +107,19 @@ PART
 			node = top2
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Double

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_universal.cfg
@@ -51,7 +51,7 @@ PART
     breakingForce = 192000
     breakingTorque = 192000
 	bulkheadProfiles = hx
-    tags = ?lf ?lfo adapter affix connect construct fabricate fuel hold liquid mount stru structur support
+    tags = ?lf ?lfo adapter affix connect construct fabricate fuel hold liquid mono monopropellant mount propellant stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size2_universal.cfg
@@ -51,7 +51,7 @@ PART
     breakingForce = 192000
     breakingTorque = 192000
 	bulkheadProfiles = hx
-    tags = adapter affix connect construct fabricate hold mount stru structur support
+    tags = ?lf ?lfo adapter affix connect construct fabricate fuel hold liquid mount stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_375m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_375m.cfg
@@ -45,6 +45,7 @@ PART
     breakingForce = 24320000
     breakingTorque = 24320000
 	bulkheadProfiles = hx
+    tags = adapter affix connect construct fabricate hold mount stru structur support
 
     MODULE
     {

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_375m.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_375m.cfg
@@ -45,7 +45,7 @@ PART
     breakingForce = 24320000
     breakingTorque = 24320000
 	bulkheadProfiles = hx
-    tags = adapter affix connect construct fabricate hold mount stru structur support
+    tags = adapter affix connect construct dock fabricate hold mount stru structur support
 
     MODULE
     {

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_size1_a.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_size1_a.cfg
@@ -54,6 +54,7 @@ PART
     breakingForce = 380000
     breakingTorque = 380000
 	bulkheadProfiles = hx
+    tags = adapter affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -61,31 +62,31 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 142440.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_v
@@ -93,7 +94,7 @@ PART
 			node = bottom5
 			node = bottom6
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_h
@@ -101,7 +102,7 @@ PART
 			node = bottom7
 			node = bottom8
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_f
@@ -110,7 +111,7 @@ PART
 			node = bottom3
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_b
@@ -119,7 +120,7 @@ PART
 			node = bottom1
 			node = bottom2
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_l
@@ -128,7 +129,7 @@ PART
 			node = bottom2
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_r
@@ -137,7 +138,7 @@ PART
 			node = bottom1
 			node = bottom3
 		}
-		
+
 		SUBTYPE
 		{
 			name = 2_2

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_size2_a.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_size2_a.cfg
@@ -56,6 +56,7 @@ PART
     breakingForce = 380000
     breakingTorque = 380000
 	bulkheadProfiles = hx
+    tags = adapter affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -63,31 +64,31 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 186500.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = topNodeSwitch
 		switcherDescription = Top Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = top0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Double
@@ -95,19 +96,19 @@ PART
 			node = top2
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_v
@@ -115,7 +116,7 @@ PART
 			node = bottom5
 			node = bottom6
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_h
@@ -123,7 +124,7 @@ PART
 			node = bottom7
 			node = bottom8
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_f
@@ -132,7 +133,7 @@ PART
 			node = bottom3
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_b
@@ -141,7 +142,7 @@ PART
 			node = bottom1
 			node = bottom2
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_l
@@ -150,7 +151,7 @@ PART
 			node = bottom2
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_r
@@ -159,7 +160,7 @@ PART
 			node = bottom1
 			node = bottom3
 		}
-		
+
 		SUBTYPE
 		{
 			name = 2_2

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_size2_b.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_adapter_size2_b.cfg
@@ -57,6 +57,7 @@ PART
     breakingForce = 95000
     breakingTorque = 95000
 	bulkheadProfiles = hx,srf
+    tags = adapter affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -64,31 +65,31 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 376120.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
 			tankType = B9_HX_LFO
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = topNodeSwitch
 		switcherDescription = Top Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = top0
 		}
-		
+
 		SUBTYPE
 		{
 			name = Double
@@ -96,19 +97,19 @@ PART
 			node = top2
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_v
@@ -116,7 +117,7 @@ PART
 			node = bottom5
 			node = bottom6
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_h
@@ -124,7 +125,7 @@ PART
 			node = bottom7
 			node = bottom8
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_f
@@ -133,7 +134,7 @@ PART
 			node = bottom3
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_b
@@ -142,7 +143,7 @@ PART
 			node = bottom1
 			node = bottom2
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_l
@@ -151,7 +152,7 @@ PART
 			node = bottom2
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_r
@@ -160,7 +161,7 @@ PART
 			node = bottom1
 			node = bottom3
 		}
-		
+
 		SUBTYPE
 		{
 			name = 2_2

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_hangar.cfg
@@ -68,7 +68,7 @@ PART
     breakingForce = 3800000
     breakingTorque = 3800000
 	bulkheadProfiles = hx,srfAttach
-	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mono monopropellant mount multi outpost plate propellant stru structur support
+	tags = build connect construct fabricate hold mount multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_hangar.cfg
@@ -68,7 +68,7 @@ PART
     breakingForce = 3800000
     breakingTorque = 3800000
 	bulkheadProfiles = hx,srfAttach
-	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mount multi outpost plate propellant stru structur support
+	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mono monopropellant mount multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_hangar.cfg
@@ -34,7 +34,7 @@ PART
     node_stack_bottom7 =  3.41,   -4,    0,       0,  -1,    0,   9
     node_stack_bottom8 = -3.41,   -4,    0,       0,  -1,    0,   9
     node_attach        =  0,       0,    6.8284,  0,   0,    1
-	
+
     node_stack_front   =  0.0,     0.0,  6.52843, 0.0, 0.0,  1.0, 4
     node_stack_back    =  0.0,     0.0, -6.52843, 0.0, 0.0, -1.0, 4
     node_stack_left    =  6.52843, 0.0,  0.0,     1.0, 0.0,  0.0, 4
@@ -68,32 +68,33 @@ PART
     breakingForce = 3800000
     breakingTorque = 3800000
 	bulkheadProfiles = hx,srfAttach
-	
+    tags = base build construct fabricate fuel hold hollow mount shield stru structur support
+
 	DRAG_CUBE
 	{
 		cube = Default, 108.5491,0.9394761,1.521537, 108.5491,0.9394761,1.521537, 182.6481,1,0.09647061, 182.6481,1,0.09647061, 108.5491,0.9394761,1.521537, 108.5491,0.9394761,1.521537, 0,0,0, 13.65686,8.000002,13.65686
 	}
-	
+
 	// size3_hangar1 @ 278.8124m3
 	// size3_hangar2 @ 238.3271m3
 	// size3_hangar3 @ 197.8418m3
 	// size3_hangar4 @ 157.3565m3
 	// size3_hangar5 @ 116.8712m3
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = hangarSwitch
 		switcherDescription = Hangar Type
 		affectDragCubes = false
-		
+
 		SUBTYPE
 		{
 			name = Enclosed
 			addedMass = 11.26
 			transform = model_hx_size3_hangar1
 		}
-		
+
 		SUBTYPE
 		{
 			name = Semi_A
@@ -102,7 +103,7 @@ PART
 			transform = model_hx_size3_hangar2
 			node = right
 		}
-		
+
 		SUBTYPE
 		{
 			name = Semi_B
@@ -112,7 +113,7 @@ PART
 			node = left
 			node = right
 		}
-		
+
 		SUBTYPE
 		{
 			name = Semi_C
@@ -123,7 +124,7 @@ PART
 			node = left
 			node = right
 		}
-		
+
 		SUBTYPE
 		{
 			name = Open
@@ -135,35 +136,35 @@ PART
 			node = right
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = supportSwitch
 		switcherDescription = Support Variant
 		affectDragCubes = false
-		
+
 		SUBTYPE
 		{
 			name = A
 			title = Support A
 			transform = model_hx_size3_hangar_support1
 		}
-		
+
 		SUBTYPE
 		{
 			name = AB
 			title = Support AB
 			transform = model_hx_size3_hangar_support2
 		}
-		
+
 		SUBTYPE
 		{
 			name = B
 			title = Support B
 			transform = model_hx_size3_hangar_support3
 		}
-		
+
 		SUBTYPE
 		{
 			name = None
@@ -171,19 +172,19 @@ PART
 			transform = model_hx_size3_hangar_support4
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = topNodeSwitch
 		switcherDescription = Top Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = top0
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_v
@@ -191,7 +192,7 @@ PART
 			node = top5
 			node = top6
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_h
@@ -199,7 +200,7 @@ PART
 			node = top7
 			node = top8
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_f
@@ -208,7 +209,7 @@ PART
 			node = top3
 			node = top4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_b
@@ -217,7 +218,7 @@ PART
 			node = top1
 			node = top2
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_l
@@ -226,7 +227,7 @@ PART
 			node = top2
 			node = top4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_r
@@ -235,7 +236,7 @@ PART
 			node = top1
 			node = top3
 		}
-		
+
 		SUBTYPE
 		{
 			name = 2_2
@@ -246,19 +247,19 @@ PART
 			node = top4
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_v
@@ -266,7 +267,7 @@ PART
 			node = bottom5
 			node = bottom6
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_h
@@ -274,7 +275,7 @@ PART
 			node = bottom7
 			node = bottom8
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_f
@@ -283,7 +284,7 @@ PART
 			node = bottom3
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_b
@@ -292,7 +293,7 @@ PART
 			node = bottom1
 			node = bottom2
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_l
@@ -301,7 +302,7 @@ PART
 			node = bottom2
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_r
@@ -310,7 +311,7 @@ PART
 			node = bottom1
 			node = bottom3
 		}
-		
+
 		SUBTYPE
 		{
 			name = 2_2
@@ -321,14 +322,14 @@ PART
 			node = bottom4
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleCargoBay
 		DeployModuleIndex = 0
 		closedPosition = 0
 		lookupRadius = 4
-		
+
 		nodeOuterForeID = top
 		nodeOuterAftID = bottom
 	}

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_hangar.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_hangar.cfg
@@ -68,7 +68,7 @@ PART
     breakingForce = 3800000
     breakingTorque = 3800000
 	bulkheadProfiles = hx,srfAttach
-    tags = base build construct fabricate fuel hold hollow mount shield stru structur support
+	tags = ?lf ?lfo build connect construct fabricate fuel hold liquid mount multi outpost plate propellant stru structur support
 
 	DRAG_CUBE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_universal.cfg
@@ -63,7 +63,7 @@ PART
     breakingForce = 380000
     breakingTorque = 380000
 	bulkheadProfiles = hx,srf
-    tags = adapter affix connect construct fabricate hold mount stru structur support
+    tags = ?lf ?lfo adapter affix connect construct fabricate fuel hold liquid mount stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_universal.cfg
@@ -63,7 +63,7 @@ PART
     breakingForce = 380000
     breakingTorque = 380000
 	bulkheadProfiles = hx,srf
-    tags = ?lf ?lfo adapter affix connect construct fabricate fuel hold liquid mount stru structur support
+    tags = ?lf ?lfo adapter affix connect construct fabricate fuel hold liquid mono monopropellant mount propellant stru structur support
 
 	MODULE
 	{

--- a/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_universal.cfg
+++ b/GameData/B9_Aerospace_HX/Parts/Structure_HX/model_hx_size3_universal.cfg
@@ -63,6 +63,7 @@ PART
     breakingForce = 380000
     breakingTorque = 380000
 	bulkheadProfiles = hx,srf
+    tags = adapter affix connect construct fabricate hold mount stru structur support
 
 	MODULE
 	{
@@ -70,13 +71,13 @@ PART
 		moduleID = fuelSwitch
 		switcherDescription = Tank Setup
 		baseVolume = 252600.0
-	
+
 		SUBTYPE
 		{
 			name = Structural
 			transform = model_hx_size3_structure1
 		}
-	
+
 		SUBTYPE
 		{
 			name = LFO
@@ -84,19 +85,19 @@ PART
 			transform = model_hx_size3_fuel1
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = topNodeSwitch
 		switcherDescription = Top Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = top0
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_v
@@ -104,7 +105,7 @@ PART
 			node = top5
 			node = top6
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_h
@@ -112,7 +113,7 @@ PART
 			node = top7
 			node = top8
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_f
@@ -121,7 +122,7 @@ PART
 			node = top3
 			node = top4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_b
@@ -130,7 +131,7 @@ PART
 			node = top1
 			node = top2
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_l
@@ -139,7 +140,7 @@ PART
 			node = top2
 			node = top4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_r
@@ -148,7 +149,7 @@ PART
 			node = top1
 			node = top3
 		}
-		
+
 		SUBTYPE
 		{
 			name = 2_2
@@ -159,19 +160,19 @@ PART
 			node = top4
 		}
 	}
-	
+
 	MODULE
 	{
 		name = ModuleB9PartSwitch
 		moduleID = bottomNodeSwitch
 		switcherDescription = Bottom Node Setup
-		
+
 		SUBTYPE
 		{
 			name = Single
 			node = bottom0
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_v
@@ -179,7 +180,7 @@ PART
 			node = bottom5
 			node = bottom6
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_1_h
@@ -187,7 +188,7 @@ PART
 			node = bottom7
 			node = bottom8
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_f
@@ -196,7 +197,7 @@ PART
 			node = bottom3
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_b
@@ -205,7 +206,7 @@ PART
 			node = bottom1
 			node = bottom2
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_l
@@ -214,7 +215,7 @@ PART
 			node = bottom2
 			node = bottom4
 		}
-		
+
 		SUBTYPE
 		{
 			name = 1_2_r
@@ -223,7 +224,7 @@ PART
 			node = bottom1
 			node = bottom3
 		}
-		
+
 		SUBTYPE
 		{
 			name = 2_2

--- a/GameData/B9_Aerospace_Legacy/Parts/Aero_HL_Adapter_MK4/part.cfg
+++ b/GameData/B9_Aerospace_Legacy/Parts/Aero_HL_Adapter_MK4/part.cfg
@@ -42,4 +42,5 @@ PART
     maxTemp = 2300 // = 3400
     fuelCrossFeed = True
 	bulkheadProfiles = size3
+    tags = adapter affix cargo connect join mount support
 }


### PR DESCRIPTION
All parts in the B9_Aerospace and B9_Aerospace_HX have had stock tags
added to them. Tags belong in the 'Part' heading of each part, outside
of any sub-headings. Tags are ordered alphabetically.

There were whites pace changes that were done automatically due to the editor i was using, but they should not have affected anything substantial. 