### PR TITLE
Added new variable for skin temperature and added suitable values by …

### DIFF
--- a/GameData/B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a.cfg
@@ -31,7 +31,8 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 
-	maxTemp = 2200
+	maxTemp = 1000 // = 2200
+	skinMaxTemp = 2200
 	emissiveConstant = 0.8
 
 	vesselType = Ship

--- a/GameData/B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a_intake.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2_Cockpit/body_mk2_cockpit_a_intake.cfg
@@ -31,7 +31,8 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 
-	maxTemp = 2200
+	maxTemp = 1000 // = 2200
+	skinMaxTemp = 2200
 	emissiveConstant = 0.8
 
 	vesselType = Ship

--- a/GameData/B9_Aerospace/Parts/Cockpit_HL/HL_Aero_Cockpit.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_HL/HL_Aero_Cockpit.cfg
@@ -37,7 +37,8 @@ PART
     crashTolerance = 45
     breakingForce = 400
     breakingTorque = 400
-    maxTemp = 2700 // = 3400
+    maxTemp = 1500 // = 3400
+	skinMaxTemp = 2700
 	bulkheadProfiles = size3
 
     stagingIcon = COMMAND_POD

--- a/GameData/B9_Aerospace/Parts/Cockpit_M27/Cockpit_M27.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_M27/Cockpit_M27.cfg
@@ -38,7 +38,8 @@ PART
     crashTolerance = 45
     breakingForce = 256
     breakingTorque = 256
-    maxTemp = 2000 // = 3400
+    maxTemp = 1000 // = 3400
+	skinMaxTemp = 2000
 	bulkheadProfiles = size2
 
     stagingIcon = COMMAND_POD

--- a/GameData/B9_Aerospace/Parts/Cockpit_MK5/Cockpit_MK5.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_MK5/Cockpit_MK5.cfg
@@ -35,7 +35,8 @@ PART
     crashTolerance = 45
     breakingForce = 300
     breakingTorque = 300
-    maxTemp = 2500 // = 3400
+    maxTemp = 1300 // = 3400
+	skinMaxTemp = 2500
 	bulkheadProfiles = size2
 
     stagingIcon = COMMAND_POD

--- a/GameData/B9_Aerospace/Parts/Cockpit_S2/Cockpit_S2.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S2/Cockpit_S2.cfg
@@ -37,7 +37,8 @@ PART
     crashTolerance = 45
     breakingForce = 400
     breakingTorque = 400
-    maxTemp = 2500 // = 3400
+    maxTemp = 1300 // = 3400
+	skinMaxTemp = 2500
 	bulkheadProfiles = size2
 
     stagingIcon = COMMAND_POD

--- a/GameData/B9_Aerospace/Parts/Cockpit_S3/Cockpit_S3.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_S3/Cockpit_S3.cfg
@@ -37,7 +37,8 @@ PART
     crashTolerance = 45
     breakingForce = 400
     breakingTorque = 400
-    maxTemp = 2700// = 3400
+    maxTemp = 1500 // = 3400
+	skinMaxTemp = 2700
 	bulkheadProfiles = size2
 
     stagingIcon = COMMAND_POD


### PR DESCRIPTION
Hey blowfish so I found a way to contribute at least something to this update. I noticed that a new variable has been added to cockpit parts. This variable called skinMaxTemp is for the max temperature of the skin obviously. The old maxTemp seems now to be used to determine when a Kerbal will be fried alive. So I added that new variable, applied the old maxTemp value there and added a suitable value to maxTemp by comparing to stock.