### PR TITLE
Update B9_Aerospace-DRE.cfg

### DIFF
--- a/GameData/B9_Aerospace/B9_Aerospace-DRE.cfg
+++ b/GameData/B9_Aerospace/B9_Aerospace-DRE.cfg
@@ -1,446 +1,900 @@
 @PART[B9_Adapter_C125]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Adapter_SM1]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Adapter_SM2]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Adapter_LM3]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Adapter_SM3]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Adapter_Y1]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_AirBrake_Surface]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+    @maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_AirBrake_Surface_Large]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 
 @PART[B9_Aero_HL_Adapter_Front]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Adapter_MK4]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Structure_1m_U]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Adapter_2m_Side]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Structure_2m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Structure_2m_A]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Structure_05m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_SAS_05m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Structure_6m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Tail_8m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Cargo_Tail_Wide]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Cargo_A]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Cargo_B]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Body_Cargo_C]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Extension_A]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Extension_B1]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_HL_Extension_C]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_MK1_Junction]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_Intake_CLR]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_Intake_DSI]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_Intake_DSIX]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_Intake_Mount]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_Intake_RBM]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_Intake_RNM]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Aero_T2_Tail]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 
 @PART[B9_Cargo_M2_Adapter]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cargo_M2_Separator]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cargo_M2_Body]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_D25]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[HL_Aero_Cockpit]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_M27]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Body_Mk2_Cockpit|B9_Body_Mk2_Cockpit_Intake]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_MK5]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Adapter]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Body_RCS]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Body]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Control_SAS]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Body_05m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Body_6m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
-}
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 @PART[B9_Cockpit_S2_Body_Cargo_2m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Body_Cargo_6m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_BodyLarge_Cargo_2m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_BodyLarge_Cargo_6m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Body_Crew]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Body_Crew_6m]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_Body_Tail]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_BodyLarge]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_BodyLarge_Back_EngineMount1]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_BodyLarge_Back_EngineMount2]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_BodyLarge_Back]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_BodyLarge_Front]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S2_BodyLarge_Front2]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_S3]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_RCS_Block_R5]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_RCS_Block_R6]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_RCS_Block_R12]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_RCS_Port_R1]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_RCS_Port_R1A]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_RCS_Tank_MT1]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_RCS_Tank_MT4]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_Jet_Pod_Medium]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
     temperatureRatio = 1800
@@ -451,10 +905,30 @@
     }
 }
 @PART[B9_Engine_Jet_Pod_Medium_PylonR]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_Jet_Pod_Medium_PylonS]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_Jet_Pod_Small]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
     temperatureRatio = 1800
@@ -465,281 +939,643 @@
     }
 }
 @PART[B9_Engine_Jet_Pod_Small_PylonR]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_Jet_Pod_Small_PylonS]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_Jet_Turbofan_F119]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEnginesFX],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_Jet_Turbojet]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEnginesFX],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_L2_Atlas]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEnginesFX],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_SABRE_M_Body]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_SABRE_S_Body]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_SABRE_Intake_M]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_SABRE_Intake_S]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_SABRE_M]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEnginesFX],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_SABRE_S]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEnginesFX],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_T2_SRBS]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEngines*],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_T2A_SRBS]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEngines*],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
+    @maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_VA1]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEnginesFX],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_VS1]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    temperatureRatio = 1800
-    @temperatureRatio /= #$/maxTemp$
-    @maxTemp *= #$/temperatureRatio$
-    @MODULE[ModuleEnginesFX],* {
-        @heatProduction *= #$/temperatureRatio$
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Engine_VA1_Intake]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Engine_VS1_Nosecone]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 
 @PART[B9_Structure_L1_Ladder]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_L2_Ladder]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_L4_Ladder]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_L8_Ladder]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_R0_Railing]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_R1_Railing]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_R2_Railing]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_R4_Railing]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_PA_Adapter]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_P1_Surface_Half]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1600
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_P2_Surface_Half]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1600
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_P4_Surface_Half]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1600
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_P8_Surface_Half]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1600
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_P1_Surface]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1600
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_P2_Surface]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1600
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_P4_Surface]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1600
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_P8_Surface]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1600
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_PA_Adapter]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_SN_Strut]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1800
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_SNM_Strut]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1800
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Structure_StackSeparator_MSR]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1800
-    @MODULE[ModuleEnginesFX] {
-        @heatProduction = 290
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
 }
 @PART[B9_Utility_DockingPort_CDP]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1500
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Utility_InfoDrive]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 
 @PART[B9_Utility_Leg_H50]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Utility_Leg_H50P]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Utility_Light_A1_Closed]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Utility_Light_A1_White]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Utility_Light_A4_White]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Utility_Light_A8_White]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Utility_Light_N1_White]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Utility_Light_N1_Large_White]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_MK2_Nosecone]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_MK2_Nosecone_Science]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Cockpit_MK2_Nosecone_ASAS]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1700
-    MODULE {
-        name = ModuleHeatShield
-        direction = 0, 0, 0
-        reflective = 0.25
-    }
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_ASAS]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }
 @PART[B9_Control_ACU]:FOR[B9_Aerospace]:NEEDS[DeadlyReentry] {
-    @maxTemp = 1450
+	@maxTemp = 850
+	@emissiveConstant = 0.85
+	skinMaxTemp = 2706
+	skinThermalMassModifier = 0.436
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.815
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
 }


### PR DESCRIPTION
Updated DRE config. These values are not fine tuned for parts like originally intended, but instead are copied/pasted from DRE's own config values for spaceplane parts. The original fine tuning was done in a world without stock re-entry heating.