### PR TITLE
Kerbnet access for drone cores

### DIFF
--- a/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m_sas.cfg
+++ b/GameData/B9_Aerospace/Parts/Body_Mk2/body_mk2_section_0m_sas.cfg
@@ -9,7 +9,7 @@ PART
     node_stack_top    =  0.0000,  0.2500,  0.0000,  0.0000,  1.0000,  0.0000, 1
     node_stack_bottom =  0.0000, -0.2500,  0.0000,  0.0000, -1.0000,  0.0000, 1
 
-    TechRequired = highAltitudeFlight
+    TechRequired = automation
     entryCost = 25000
     cost = 5000
 
@@ -89,6 +89,22 @@ PART
 	{
 		name = ModuleSAS
 		SASServiceLevel = 3
+	}
+	
+	MODULE
+	{
+		name = ModuleKerbNetAccess
+		EnhancedSituationMask = 24
+		EnhancedMinimumFoV = 45
+		EnhancedMaximumFoV = 135
+		MinimumFoV = 10
+		MaximumFoV = 20
+		AnomalyDetection = 0.48
+		DISPLAY_MODES
+		{
+			Mode = Biome
+			Mode = Terrain
+		}
 	}
 	
 	MODULE

--- a/GameData/B9_Aerospace/Parts/Cockpit_D25/Cockpit_D25.cfg
+++ b/GameData/B9_Aerospace/Parts/Cockpit_D25/Cockpit_D25.cfg
@@ -18,7 +18,7 @@ PART
     // --- FX definitions ---
 
     // --- editor parameters ---
-    TechRequired = advUnmanned
+    TechRequired = automation
     entryCost = 12000
     cost = 3200
     category = Pods
@@ -85,6 +85,22 @@ PART
             rate = 4.375
         }
     }
+	
+	MODULE
+	{
+		name = ModuleKerbNetAccess
+		EnhancedSituationMask = 24
+		EnhancedMinimumFoV = 45
+		EnhancedMaximumFoV = 135
+		MinimumFoV = 10
+		MaximumFoV = 20
+		AnomalyDetection = 0.48
+		DISPLAY_MODES
+		{
+			Mode = Biome
+			Mode = Terrain
+		}
+	}
 	
 	MODULE
 	{

--- a/GameData/B9_Aerospace_Legacy/Parts/Cockpit_MK1_Body/Body-ACU.cfg
+++ b/GameData/B9_Aerospace_Legacy/Parts/Cockpit_MK1_Body/Body-ACU.cfg
@@ -18,7 +18,7 @@ PART
     node_stack_bottom = 0.0, -0.25, 0.0, 0.0, -1.0, 0.0, 1
 
     // --- editor parameters ---
-    TechRequired = advUnmanned
+    TechRequired = automation
     entryCost = 2700
     cost = 1350
     category = Pods
@@ -84,6 +84,22 @@ PART
     {
         name = ModuleSAS
     }
+	
+	MODULE
+	{
+		name = ModuleKerbNetAccess
+		EnhancedSituationMask = 24
+		EnhancedMinimumFoV = 45
+		EnhancedMaximumFoV = 135
+		MinimumFoV = 10
+		MaximumFoV = 20
+		AnomalyDetection = 0.48
+		DISPLAY_MODES
+		{
+			Mode = Biome
+			Mode = Terrain
+		}
+	}
 	
 	MODULE
 	{


### PR DESCRIPTION
Hello blowfish,

we missed something. All probe cores are suppossed to have access to Kerbnet. I added this to our cores now. They have the same Kerbnet access that Porkjets MK2 Probe core has. I also put the cores into the technode automation, because that is where Porkjets MK2 Probe core resides.