### PR TITLE
Split up HL fuselage switchers

### DIFF
--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/05m-Universal.cfg
@@ -45,105 +45,101 @@ PART
     fuelCrossFeed = True
     breakingForce = 203040
     breakingTorque = 203040
-	bulkheadProfiles = size3, srf
+    bulkheadProfiles = size3, srf
     tags = aircraft airlin airliner connect contain fuel fueltank hold ?lf ?lfo liquid mono monopropellant payload propellant structur tank
 
-	MODULE
-	{
-		name = ModuleB9PartSwitch
-		moduleID = fuelSwitch
-		switcherDescription = Tank Setup
-		baseVolume = 900.0
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Tank
+        switcherDescriptionPlural = Tank Types
+        baseVolume = 900.0
 
-		SUBTYPE
-		{
-			name = HL_Structural
-			title = HL-Str
-			transform = STR
-		}
+        SUBTYPE
+        {
+            name = str-a
+            title = Structural A
+            transform = STR
+            transform = STR_R1
+            transform = Adapter_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_LF
-			title = HL-LF
-			tankType = B9_LiquidFuel
-			transform = LF
-		}
+        SUBTYPE
+        {
+            name = str-b
+            title = Structural B
+            transform = STR
+            transform = STR_R2
+            transform = Adapter_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_LFO
-			title = HL-LFO
-			tankType = B9_LFO
-			transform = LFO
-		}
+        SUBTYPE
+        {
+            name = LiquidFuel
+            tankType = B9_LiquidFuel
+            transform = LF
+            transform = LF_R
+            transform = Adapter_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_RCS
-			title = HL-RCS
-			tankType = B9_MonoProp
-			transform = RCS
-		}
+        SUBTYPE
+        {
+            name = LFO
+            tankType = B9_LFO
+            transform = LFO
+            transform = LFO_R
+            transform = Adapter_R
+        }
 
-		SUBTYPE
-		{
-			name = Round_Structural_1
-			title = Round-Str1
-			addedMass = 0.026
-			addedCost = 45.0
-			transform = STR_R1
-		}
+        SUBTYPE
+        {
+            name = MonoProp
+            tankType = B9_MonoProp
+            transform = RCS
+            transform = RCS_R
+            transform = Adapter_R
+        }
+    }
 
-		SUBTYPE
-		{
-			name = Round_Structural_2
-			title = Round-Str2
-			addedMass = 0.026
-			addedCost = 45.0
-			transform = STR_R2
-		}
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = meshSwitch
+        parentID = fuelSwitch
+        switcherDescription = Variant
+        switcherDescriptionPlural = Variants
 
-		SUBTYPE
-		{
-			name = Round_LF
-			title = Round-LF
-			addedMass = 0.026
-			addedCost = 45.0
-			volumeAdded = 40.0
-			tankType = B9_LiquidFuel
-			transform = LF_R
-		}
+        SUBTYPE
+        {
+            name = HL
+            transform = STR
+            transform = LF
+            transform = LFO
+            transform = RCS
+        }
 
-		SUBTYPE
-		{
-			name = Round_LFO
-			title = Round-LFO
-			addedMass = 0.026
-			addedCost = 45.0
-			volumeAdded = 40.0
-			tankType = B9_LFO
-			transform = LFO_R
-		}
+        SUBTYPE
+        {
+            name = Round
+            addedMass = 0.026
+            addedCost = 45.0
+            volumeAddedToParent = 40.0
+            transform = STR_R1
+            transform = STR_R2
+            transform = LF_R
+            transform = LFO_R
+            transform = RCS_R
+        }
 
-		SUBTYPE
-		{
-			name = Round_RCS
-			title = Round-RCS
-			addedMass = 0.026
-			addedCost = 45.0
-			volumeAdded = 40.0
-			tankType = B9_MonoProp
-			transform = RCS_R
-		}
-
-		SUBTYPE
-		{
-			name = HL_Round_Adapter_Structural
-			title = HL Adapter
-			addedMass = 0.013
-			addedCost = 22.0
-			transform = Adapter_R
-		}
-	}
+        SUBTYPE
+        {
+            name = hl-round-adapter
+            title = HL Adapter
+            addedMass = 0.013
+            addedCost = 22.0
+            volumeAddedToParent = 20.0
+            transform = Adapter_R
+        }
+    }
 }

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/1m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/1m-Universal.cfg
@@ -45,87 +45,76 @@ PART
     fuelCrossFeed = True
     breakingForce = 67680
     breakingTorque = 67680
-	bulkheadProfiles = size3
+    bulkheadProfiles = size3
     tags = aircraft airlin airliner connect contain fuel fueltank fuselage hold ?lf ?lfo liquid mono monopropellant propellant structur tank tube
 
-	MODULE
-	{
-		name = ModuleB9PartSwitch
-		moduleID = fuelSwitch
-		switcherDescription = Tank Setup
-		baseVolume = 1780.0
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Tank
+        switcherDescriptionPlural = Tank Types
+        baseVolume = 1780.0
 
-		SUBTYPE
-		{
-			name = HL_Structural
-			title = HL-Str
-			transform = STR
-		}
+        SUBTYPE
+        {
+            name = Structural
+            transform = STR
+            transform = STR_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_LF
-			title = HL-LF
-			tankType = B9_LiquidFuel
-			transform = LF
-		}
+        SUBTYPE
+        {
+            name = LiquidFuel
+            tankType = B9_LiquidFuel
+            transform = LF
+            transform = LF_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_LFO
-			title = HL-LFO
-			tankType = B9_LFO
-			transform = LFO
-		}
+        SUBTYPE
+        {
+            name = LFO
+            tankType = B9_LFO
+            transform = LFO
+            transform = LFO_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_RCS
-			title = HL-RCS
-			tankType = B9_MonoProp
-			transform = RCS
-		}
+        SUBTYPE
+        {
+            name = MonoProp
+            tankType = B9_MonoProp
+            transform = RCS
+            transform = RCS_R
+        }
+    }
 
-		SUBTYPE
-		{
-			name = Round_Structural
-			title = Round-Str
-			addedMass = 0.052
-			addedCost = 85.0
-			transform = STR_R
-		}
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = meshSwitch
+        parentID = fuelSwitch
+        switcherDescription = Variant
+        switcherDescriptionPlural = Variants
 
-		SUBTYPE
-		{
-			name = Round_LF
-			title = Round-LF
-			addedMass = 0.052
-			addedCost = 85.0
-			volumeAdded = 100.0
-			tankType = B9_LiquidFuel
-			transform = LF_R
-		}
+        SUBTYPE
+        {
+            name = HL
+            transform = STR
+            transform = LF
+            transform = LFO
+            transform = RCS
+        }
 
-		SUBTYPE
-		{
-			name = Round_LFO
-			title = Round-LFO
-			addedMass = 0.052
-			addedCost = 85.0
-			volumeAdded = 100.0
-			tankType = B9_LFO
-			transform = LFO_R
-		}
-
-		SUBTYPE
-		{
-			name = Round_RCS
-			title = Round-RCS
-			addedMass = 0.052
-			addedCost = 85.0
-			volumeAdded = 100.0
-			tankType = B9_MonoProp
-			transform = RCS_R
-		}
-	}
+        SUBTYPE
+        {
+            name = Round
+            addedMass = 0.052
+            addedCost = 85.0
+            volumeAddedToParent = 100.0
+            transform = STR_R
+            transform = LF_R
+            transform = LFO_R
+            transform = RCS_R
+        }
+    }
 }

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal-Adapter.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal-Adapter.cfg
@@ -44,87 +44,62 @@ PART
     fuelCrossFeed = True
     breakingForce = 5730
     breakingTorque = 5730
-	bulkheadProfiles = size3
+    bulkheadProfiles = size3
     tags = adapter aircraft airlin airliner connect contain fuel fueltank hold ?lf ?lfo liquid mono monopropellant propellant structur tank
 
-	MODULE
-	{
-		name = ModuleB9PartSwitch
-		moduleID = fuelSwitch
-		switcherDescription = Tank Setup
-		baseVolume = 2580.0
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Tank
+        switcherDescriptionPlural = Tank Types
+        baseVolume = 2580.0
 
-		SUBTYPE
-		{
-			name = HL_Structural
-			title = HL-Str
-			transform = STR
-		}
+        SUBTYPE
+        {
+            name = Structural
+        }
 
-		SUBTYPE
-		{
-			name = HL_LF
-			title = HL-LF
-			tankType = B9_LiquidFuel
-			transform = STR
-		}
+        SUBTYPE
+        {
+            name = LiquidFuel
+            tankType = B9_LiquidFuel
+        }
 
-		SUBTYPE
-		{
-			name = HL_LFO
-			title = HL-LFO
-			tankType = B9_LFO
-			transform = STR
-		}
+        SUBTYPE
+        {
+            name = LFO
+            tankType = B9_LFO
+        }
 
-		SUBTYPE
-		{
-			name = HL_RCS
-			title = HL-RCS
-			tankType = B9_MonoProp
-			transform = STR
-		}
+        SUBTYPE
+        {
+            name = MonoProp
+            tankType = B9_MonoProp
+        }
+    }
 
-		SUBTYPE
-		{
-			name = Round_Structural
-			title = Round-Str
-			addedMass = 0.043
-			addedCost = 70.0
-			transform = STR_R
-		}
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = meshSwitch
+        parentID = fuelSwitch
+        switcherDescription = Variant
+        switcherDescriptionPlural = Variants
 
-		SUBTYPE
-		{
-			name = Round_LF
-			title = Round-LF
-			addedMass = 0.043
-			addedCost = 70.0
-			volumeAdded = 80.0
-			tankType = B9_LiquidFuel
-			transform = STR_R
-		}
+        SUBTYPE
+        {
+            name = HL
+            transform = STR
+        }
 
-		SUBTYPE
-		{
-			name = Round_LFO
-			title = Round-LFO
-			addedMass = 0.043
-			addedCost = 70.0
-			volumeAdded = 80.0
-			tankType = B9_LFO
-			transform = STR_R
-		}
-
-		SUBTYPE
-		{
-			name = Round_RCS
-			title = Round-RCS
-			addedMass = 0.043
-			addedCost = 70.0
-			volumeAdded = 80.0
-			tankType = B9_MonoProp
-			transform = STR_R
-		}
-	}
+        SUBTYPE
+        {
+            name = Round
+            addedMass = 0.043
+            addedCost = 70.0
+            volumeAddedToParent = 80.0
+            transform = STR_R
+        }
+    }
 }

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/2m-Universal.cfg
@@ -15,8 +15,8 @@ PART
 
     // --- node definitions ---
     // definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
-    node_stack_top    = 0,  1, 0,     0, 1,  0, 3
-    node_stack_bottom = 0, -1, 0,     0,  -1,  0, 3
+    node_stack_top    = 0,  1, 0,     0,  1,  0, 3
+    node_stack_bottom = 0, -1, 0,     0, -1,  0, 3
     node_attach       = 0,  0, 1.875, 0,  0, -1
 
     // --- FX definitions ---
@@ -44,81 +44,76 @@ PART
     fuelCrossFeed = True
     breakingForce = 12690
     breakingTorque = 12690
-	bulkheadProfiles = size3, srf
+    bulkheadProfiles = size3, srf
     tags = aircraft airlin airliner connect contain fuel fueltank fuselage hold ?lf ?lfo liquid mono monopropellant propellant structur tank tube
 
-	MODULE
-	{
-		name = ModuleB9PartSwitch
-		moduleID = fuelSwitch
-		switcherDescription = Tank Setup
-		baseVolume = 3580.0
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Tank
+        switcherDescriptionPlural = Tank Types
+        baseVolume = 3580.0
 
-		SUBTYPE
-		{
-			name = HL_Structural
-			title = HL-Str
-			transform = STR
-		}
+        SUBTYPE
+        {
+            name = Structural
+            transform = STR
+            transform = STR_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_LF
-			title = HL-LF
-			tankType = B9_LiquidFuel
-			transform = LF
-		}
+        SUBTYPE
+        {
+            name = LiquidFuel
+            tankType = B9_LiquidFuel
+            transform = LF
+            transform = LF_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_LFO
-			title = HL-LFO
-			tankType = B9_LFO
-			transform = LFO
-		}
+        SUBTYPE
+        {
+            name = LFO
+            tankType = B9_LFO
+            transform = LFO
+            transform = LFO_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_RCS
-			title = HL-RCS
-			tankType = B9_MonoProp
-			transform = RCS
-		}
+        SUBTYPE
+        {
+            name = MonoProp
+            tankType = B9_MonoProp
+            transform = RCS
+            transform = RCS_R
+        }
+    }
 
-		SUBTYPE
-		{
-			name = Round_Structural
-			title = Round-Str
-			addedMass = 0.104
-			addedCost = 180.0
-			transform = STR_R
-		}
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = meshSwitch
+        parentID = fuelSwitch
+        switcherDescription = Variant
+        switcherDescriptionPlural = Variants
 
-		SUBTYPE
-		{
-			name = Round_LF
-			title = Round-LF
-			volumeAdded = 200.0
-			tankType = B9_LiquidFuel
-			transform = LF_R
-		}
+        SUBTYPE
+        {
+            name = HL
+            transform = STR
+            transform = LF
+            transform = LFO
+            transform = RCS
+        }
 
-		SUBTYPE
-		{
-			name = Round_LFO
-			title = Round-LFO
-			volumeAdded = 200.0
-			tankType = B9_LFO
-			transform = LFO_R
-		}
-
-		SUBTYPE
-		{
-			name = Round_RCS
-			title = Round-RCS
-			volumeAdded = 200.0
-			tankType = B9_MonoProp
-			transform = RCS_R
-		}
-	}
+        SUBTYPE
+        {
+            name = Round
+            addedMass = 0.104
+            addedCost = 180.0
+            volumeAddedToParent = 200.0
+            transform = STR_R
+            transform = LF_R
+            transform = LFO_R
+            transform = RCS_R
+        }
+    }
 }

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/6m-Universal.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/6m-Universal.cfg
@@ -44,68 +44,68 @@ PART
     fuelCrossFeed = True
     breakingForce = 1410
     breakingTorque = 1410
-	bulkheadProfiles = size3, srf
+    bulkheadProfiles = size3, srf
     tags = aircraft airlin airliner connect contain fuel fueltank hold ?lf ?lfo liquid mono monopropellant propellant structur tank
 
-	MODULE
-	{
-		name = ModuleB9PartSwitch
-		moduleID = fuelSwitch
-		switcherDescription = Tank Setup
-		baseVolume = 10720.0
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Tank
+        switcherDescriptionPlural = Tank Types
+        baseVolume = 10720.0
 
-		SUBTYPE
-		{
-			name = HL_Structural
-			title = HL-Str
-			transform = STR
-		}
+        SUBTYPE
+        {
+            name = Structural
+            transform = STR
+            transform = STR_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_LF
-			title = HL-LF
-			tankType = B9_LiquidFuel
-			transform = LF
-		}
+        SUBTYPE
+        {
+            name = LiquidFuel
+            tankType = B9_LiquidFuel
+            transform = LF
+            transform = LF_R
+        }
 
-		SUBTYPE
-		{
-			name = HL_LFO
-			title = HL-LFO
-			tankType = B9_LFO
-			transform = LFO
-		}
+        SUBTYPE
+        {
+            name = LFO
+            tankType = B9_LFO
+            transform = LFO
+            transform = LFO_R
+        }
+    }
 
-		SUBTYPE
-		{
-			name = Round_Structural
-			title = Round-Str
-			addedMass = 0.311
-			addedCost = 530.0
-			transform = STR_R
-		}
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = meshSwitch
+        parentID = fuelSwitch
+        switcherDescription = Variant
+        switcherDescriptionPlural = Variants
 
-		SUBTYPE
-		{
-			name = Round_LF
-			title = Round-LF
-			addedMass = 0.311
-			addedCost = 530.0
-			volumeAdded = 600.0
-			tankType = B9_LiquidFuel
-			transform = LF_R
-		}
+        SUBTYPE
+        {
+            name = HL
+            transform = STR
+            transform = LF
+            transform = LFO
+            transform = RCS
+        }
 
-		SUBTYPE
-		{
-			name = Round_LFO
-			title = Round-LFO
-			addedMass = 0.311
-			addedCost = 530.0
-			volumeAdded = 600.0
-			tankType = B9_LFO
-			transform = LFO_R
-		}
-	}
+        SUBTYPE
+        {
+            name = Round
+            addedMass = 0.311
+            addedCost = 530.0
+            volumeAddedToParent = 600.0
+            transform = STR_R
+            transform = LF_R
+            transform = LFO_R
+            transform = RCS_R
+        }
+    }
 }

--- a/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail.cfg
+++ b/GameData/B9_Aerospace/Parts/Aero_HL_Body/8m-Universal-Tail.cfg
@@ -43,138 +43,76 @@ PART
     fuelCrossFeed = True
     breakingForce = 2762
     breakingTorque = 2762
-	bulkheadProfiles = size3, srf
+    bulkheadProfiles = size3, srf
     tags = adapter aircraft airlin airliner connect contain fuel fueltank freight hold ?lf ?lfo liquid mono monopropellant propellant structur tail tank tube
 
-	MODULE
-	{
-		name = ModuleB9PartSwitch
-		moduleID = fuelSwitch
-		switcherDescription = Tank
-		switcherDescriptionPlural = Tank Types
-		baseVolume = 7120.0
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = fuelSwitch
+        switcherDescription = Tank
+        switcherDescriptionPlural = Tank Types
+        baseVolume = 7120.0
 
-		SUBTYPE
-		{
-			name = Raised_Structural
-			title = Raised-Str
-			transform = Tail_Raised
-		}
+        SUBTYPE
+        {
+            name = Structural
+        }
 
-		SUBTYPE
-		{
-			name = Raised_LF
-			title = Raised-LF
-			tankType = B9_LiquidFuel
-			transform = Tail_Raised
-		}
+        SUBTYPE
+        {
+            name = LiquidFuel
+            tankType = B9_LiquidFuel
+        }
 
-		SUBTYPE
-		{
-			name = Raised_LFO
-			title = Raised-LFO
-			tankType = B9_LFO
-			transform = Tail_Raised
-		}
+        SUBTYPE
+        {
+            name = LFO
+            tankType = B9_LFO
+        }
+    }
 
-		SUBTYPE
-		{
-			name = Lowered_Structural
-			title = Lowered-Str
-			transform = Tail_Lowered
-		}
+    MODULE
+    {
+        name = ModuleB9PartSwitch
+        moduleID = meshSwitch
+        parentID = fuelSwitch
+        switcherDescription = Variant
+        switcherDescriptionPlural = Variants
 
-		SUBTYPE
-		{
-			name = Lowered_LF
-			title = Lowered-LF
-			tankType = B9_LiquidFuel
-			transform = Tail_Lowered
-		}
+        SUBTYPE
+        {
+            name = Raised
+            transform = Tail_Raised
+        }
 
-		SUBTYPE
-		{
-			name = Lowered_LFO
-			title = Low-LFO
-			tankType = B9_LFO
-			transform = Tail_Lowered
-		}
+        SUBTYPE
+        {
+            name = Lowered
+            transform = Tail_Lowered
+        }
 
-		SUBTYPE
-		{
-			name = Straight_A_Structural
-			title = CenterA-Str
-			transform = Tail_Straight_A
-		}
+        SUBTYPE
+        {
+            name = Straight_A
+            title = Straight A
+            transform = Tail_Straight_A
+        }
 
-		SUBTYPE
-		{
-			name = Straight_A_LF
-			title = CenterA-LF
-			tankType = B9_LiquidFuel
-			transform = Tail_Straight_A
-		}
+        SUBTYPE
+        {
+            name = Straight_B
+            title = Straight B
+            transform = Tail_Straight_B
+        }
 
-		SUBTYPE
-		{
-			name = Straight_A_LFO
-			title = CenterA-LFO
-			tankType = B9_LFO
-			transform = Tail_Straight_A
-		}
-
-		SUBTYPE
-		{
-			name = Straight_B_Structural
-			title = CenterB-Str
-			transform = Tail_Straight_B
-		}
-
-		SUBTYPE
-		{
-			name = Straight_B_LF
-			title = CenterB-LF
-			tankType = B9_LiquidFuel
-			transform = Tail_Straight_B
-		}
-
-		SUBTYPE
-		{
-			name = Straight_B_LFO
-			title = CenterB-LFO
-			tankType = B9_LFO
-			transform = Tail_Straight_B
-		}
-
-		SUBTYPE
-		{
-			name = Flat_Structural
-			title = Flat-Str
-			addedMass = 0.685
-			addedCost = 1170.0
-			transform = Tail_Flat
-		}
-
-		SUBTYPE
-		{
-			name = Flat_LF
-			title = Flat-LF
-			addedMass = 0.685
-			addedCost = 1170.0
-			volumeAdded = 1340.0
-			tankType = B9_LiquidFuel
-			transform = Tail_Flat
-		}
-
-		SUBTYPE
-		{
-			name = Flat_LFO
-			title = Flat-LFO
-			addedMass = 0.685
-			addedCost = 1170.0
-			volumeAdded = 1340.0
-			tankType = B9_LFO
-			transform = Tail_Flat
-		}
-	}
+        SUBTYPE
+        {
+            name = Flat
+            transform = Tail_Flat
+            addedMass = 0.685
+            addedCost = 1170.0
+            volumeAddedToParent = 1340.0
+        }
+    }
 }


### PR DESCRIPTION
Now have separate mesh and fuel switchers.  This relies on 2 new
B9PartSwitch features: being able to have one module modify another's
volume, and being able to have multiple modules manage the same
transform, and only enabling it if they all agree that it should be
enabled.

Also converted tabs to spaces for consistency, and ensured that the GUI
naming is consistent.

0.5m body has some minor issues, namely (1) The two structural types are
only different on the round variant and (2) The adapter doesn't have any
tank specific meshes.  Both would require a re-export which I will
hopefully do at some point.