### PR TITLE
Add ModuleManager depends to metanetkan

### DIFF
--- a/NetKAN/B9AerospaceLegacy.netkan
+++ b/NetKAN/B9AerospaceLegacy.netkan
@@ -11,6 +11,7 @@
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?showtopic=155491"
     },
     "depends" : [
+        { "name" : "ModuleManager" },
         { "name" : "B9" }
     ],
     "suggests" : [


### PR DESCRIPTION
This mod has a **lot** of files using ModuleManager syntax, but it doesn't have MM as a dependency in CKAN.

![image](https://user-images.githubusercontent.com/1559108/82843719-a72fb180-9ea3-11ea-8ace-5f22f3c2ab2b.png)

Now the dependency is added.